### PR TITLE
Enhance EBICS Biller API with CAMT parsing capabilities and schema de…

### DIFF
--- a/ebics-biller-api.yml
+++ b/ebics-biller-api.yml
@@ -13,8 +13,9 @@ info:
     * **HTD** – list subscribed BTF formats and bank accounts
     * **BTU** – upload payment / direct-debit orders to the bank
     * **BTD** – download statements, reports and notifications from the bank
-    * **HAA** – list available BTF order types at the bank
-    * **HAC** – download customer acknowledgements (status of previous orders)
+    * **HAA** – BTFs / order types with data ready to retrieve from the bank (retrievable downloads)
+    * **HAC** – customer acknowledgements (pain.002; status reasons for prior orders / BTU)
+    * **C52 / C53 / C54 – ISO & canonical parse** – download CAMT.052 / .053 / .054 via BTD without cloud upload and return either ISO-shaped or compact canonical JSON (see `ebics-biller-camt-api.yaml`, included from `POST /client/ebics/v3/C5x-iso` and `…/C5x-canonical` in the main spec)
 
     ### General Note
 
@@ -334,33 +335,7 @@ components:
           type: array
           description: List of subscribed BTF format combinations. Use these exact values in BTU/BTD requests.
           items:
-            type: object
-            properties:
-              serviceName:
-                type: string
-                example: "MCT"
-              scope:
-                type: string
-                example: "CH"
-              serviceOption:
-                type: string
-                nullable: true
-              containerType:
-                type: string
-                nullable: true
-              msgName:
-                type: string
-                example: "pain.001"
-              msgNameVersion:
-                type: string
-                nullable: true
-                example: "03"
-              msgNameVariant:
-                type: string
-                nullable: true
-              msgNameFormat:
-                type: string
-                nullable: true
+            $ref: '#/components/schemas/HtdBusinessTransactionFormat'
         accounts:
           type: array
           description: List of bank accounts subscribed for this biller at the bank.
@@ -424,45 +399,171 @@ components:
                       type: string
                       example: "other"
 
+    HtdBusinessTransactionFormat:
+      type: object
+      description: |
+        One BTF / restricted service descriptor: same dimensions in **HTD** (subscribed formats) and **HAA** (data ready
+        to retrieve); see EBICS 3.0 §9.1.
+      properties:
+        serviceName:
+          type: string
+          nullable: true
+          description: Service name component of the BTF (e.g. MCT, PSR, EOP).
+          example: "MCT"
+        scope:
+          type: string
+          nullable: true
+          description: Country or institution scope (e.g. CH).
+          example: "CH"
+        serviceOption:
+          type: string
+          nullable: true
+          description: Optional service option qualifier when present.
+        containerType:
+          type: string
+          nullable: true
+          description: Container or packaging hint from the bank (e.g. ZIP).
+        msgName:
+          type: string
+          nullable: true
+          description: ISO 20022 message name (e.g. pain.001, pain.002, camt.053).
+          example: "pain.001"
+        msgNameVersion:
+          type: string
+          nullable: true
+          description: Message version identifier when provided.
+          example: "03"
+        msgNameVariant:
+          type: string
+          nullable: true
+          description: Message variant when provided.
+        msgNameFormat:
+          type: string
+          nullable: true
+          description: Message format qualifier when provided.
+
+    HacIdentification:
+      type: object
+      description: |
+        One `OrgId/Othr` entry from HAC **pain.002** `StsRsnInf/Orgtr/Id` (EBICS 3.0 ch.10). Key–value pair for JSON:
+        `schemeProprietary` is the semantic label (ISO 20022 `SchmeNm/Prtry`), `id` is the value (`Othr/Id`). Common
+        `schemeProprietary` examples include `UserID`, `PartnerID`, `OrderID`, `AdminOrderType`, `TimeStamp`,
+        `ServiceName`, `Scope`, `MsgName`; banks may emit further proprietary names.
+      properties:
+        id:
+          type: string
+          description: Value (`Othr/Id`); interpretation depends on `schemeProprietary`.
+          example: "camt.053"
+        schemeProprietary:
+          type: string
+          description: Semantic key (`Othr/SchmeNm/Prtry`); not an exhaustive standardized enum—values are bank-specific.
+          example: "MsgName"
+
+    HacStsRsnInfEntry:
+      type: object
+      description: |
+        One `StsRsnInf` block from HAC **pain.002** (EBICS 3.0 ch.10; ISO 20022 status reason information).
+      properties:
+        originatorName:
+          type: string
+          nullable: true
+          description: Originator name (`StsRsnInf/Orgtr/Nm`).
+        identifications:
+          type: array
+          description: Zero or more entries from `Orgtr/Id/OrgId/Othr`.
+          items:
+            $ref: '#/components/schemas/HacIdentification'
+        reasonCode:
+          type: string
+          nullable: true
+          description: Reason / result code (`StsRsnInf/Rsn`); see EBICS 3.0 ch.10.3.
+        reasonName:
+          type: string
+          nullable: true
+          description: Name from EBICS 3.0 ch.10.3 `ExternalStatusReason1Code` annex when mapped; null if the code is not in the annex.
+        reasonDescription:
+          type: string
+          nullable: true
+          description: Definition from EBICS 3.0 ch.10.3; null if the code is not in the annex.
+        additionalInformation:
+          type: array
+          description: Additional information lines (`StsRsnInf/AddtlInf`).
+          items:
+            type: string
+
     HAARequest:
       type: object
-      description: Retrieve the list of available BTF order types at the bank (H005 HAA v3).
+      description: |
+        EBICS 3.0 H005 **HAA** request: list business transaction formats (BTFs) / services for which the bank currently
+        has data ready to retrieve (available downloads; EBICS 3.0 §9.1). The JSON body is typically an empty object;
+        `ebicsUserId` and `billerId` are resolved from the JWT.
       properties: {}
 
     HAAResponse:
       type: object
-      description: Pass-through response from the EBICS HAA operation. Shape is defined by the underlying EBICS service and may evolve.
-      additionalProperties: true
+      description: |
+        Parsed **HAA** response (EBICS 3.0 §9.1): order types / services for which downloadable data is available at
+        the bank (`services`). On client or transport failure, `status` and `message` may describe the error.
       properties:
         ebicsUserId:
           type: string
+          description: Resolved EBICS user id for this response.
           example: "ZKB03305"
-        status:
-          type: string
-          nullable: true
+        services:
+          type: array
+          description: Services (BTF / restricted service descriptors) with data ready to retrieve; empty when nothing is pending.
+          items:
+            $ref: '#/components/schemas/HtdBusinessTransactionFormat'
         message:
           type: string
           nullable: true
+          description: Human-readable detail from the EBICS client or transport layer; null on success.
+        status:
+          type: string
+          nullable: true
+          description: Client-side status (e.g. `ERROR` on failure); null when the HAA order completed without client-side error.
 
     HACRequest:
       type: object
-      description: Retrieve customer acknowledgements / status of previous orders (H005 HAC v3).
-      properties: {}
+      description: |
+        Request for **HAC** (customer acknowledgement, **pain.002**) — EBICS v3 (H005). Optional date range maps to
+        `StandardOrderParams/DateRange`; **both** `startDate` and `endDate` **must** be set together, or **both** omitted.
+        `ebicsUserId` and `billerId` are resolved from the JWT.
+      properties:
+        startDate:
+          type: string
+          format: date
+          description: Optional start date (inclusive) for historical data retrieval in yyyy-MM-dd format.
+          example: "2026-04-01"
+        endDate:
+          type: string
+          format: date
+          description: Optional end date (inclusive) for historical data retrieval in yyyy-MM-dd format.
+          example: "2026-04-20"
 
     HACResponse:
       type: object
-      description: Pass-through response from the EBICS HAC operation. Shape is defined by the underlying EBICS service and may evolve.
-      additionalProperties: true
+      description: |
+        Parsed **HAC** response (EBICS 3.0 ch.10): **pain.002** with extracted `StsRsnInf` rows in `statusReasons`
+        (originator, optional identifications, reason code, optional EBICS annex name/description, and additional lines).
       properties:
         ebicsUserId:
           type: string
+          description: Resolved EBICS user id for this response.
           example: "ZKB03305"
-        status:
-          type: string
-          nullable: true
+        statusReasons:
+          type: array
+          description: Extracted status reason blocks from **pain.002** (`StsRsnInf`).
+          items:
+            $ref: '#/components/schemas/HacStsRsnInfEntry'
         message:
           type: string
           nullable: true
+          description: Human-readable detail from the EBICS client or transport layer; null on success.
+        status:
+          type: string
+          nullable: true
+          description: Client-side status (e.g. `ERROR` on failure); null when the HAC order completed without client-side error.
 
 paths:
   # ════════════════════════════════════════════
@@ -912,11 +1013,16 @@ paths:
 
   /client/ebics/v3/haa:
     post:
-      summary: HAA – List available BTF order types at the bank
+      summary: HAA – Retrievable download data
       description: |
-        Returns the list of BTF (Business Transaction Format) order types currently available at the bank for this biller.
+        EBICS 3.0 H005 **HAA** (“available downloads” / retrievable order data): lists **business transaction formats (BTFs)
+        for which the bank currently has data ready to retrieve via BTD operation**.
 
-        Use this together with **HTD** to discover which order types you can use in subsequent BTU/BTD requests.
+        **Note** This operation is usefull only for actual data (non-historical downloads). 
+
+        Contrast with **HTD**, which returns the **subscribed** BTF catalogue and account metadata. Use **HTD** to know
+        which BTF parameters are allowed for your user; use **HAA** to see which of those download types
+        actually have pending files **before** you call **BTD** for actual data (or to prioritize polling).
 
         The request body is empty — `ebicsUserId` and `billerId` are resolved internally from your JWT.
       operationId: v3Haa
@@ -930,11 +1036,46 @@ paths:
             example: {}
       responses:
         '200':
-          description: HAA executed successfully
+          description: HAA executed successfully — bank returned available-download descriptors (often under `services`).
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HAAResponse'
+              examples:
+                haaWithPendingDownloads:
+                  summary: Services with data ready to download
+                  description: |
+                    Example HAA response showing the BTFs having retrievable data for non-historical downloads (pain.002 and camt.053). 
+                    After calling BTD for actual data, the bank will mark the data as downloaded, and they will not appear in the next HAA response.
+                  value:
+                    ebicsUserId: "ZKB03305"
+                    status: null
+                    message: null
+                    services:
+                      - serviceName: "PSR"
+                        scope: "CH"
+                        serviceOption: null
+                        containerType: "ZIP"
+                        msgName: "pain.002"
+                        msgNameVersion: "10"
+                        msgNameVariant: null
+                        msgNameFormat: null
+                      - serviceName: "EOP"
+                        scope: "CH"
+                        serviceOption: null
+                        containerType: "ZIP"
+                        msgName: "camt.053"
+                        msgNameVersion: "08"
+                        msgNameVariant: null
+                        msgNameFormat: null
+                haaNothingPending:
+                  summary: No pending downloadable data available
+                  describtion: No pending downloadable data available, it means that any call to BTD for actual data (non-historical downloads) will return no data.
+                  value:
+                    ebicsUserId: "ZKB03305"
+                    status: null
+                    message: null
+                    services: []
         '401':
           description: |
             Unauthorized. Returned when:
@@ -954,16 +1095,43 @@ paths:
                   description: Returned when `ebicsStatus` flips off after the JWT was issued.
                   value:
                     error: "Unauthorized: billerPid is not valid or biller is not active"
+        '500':
+          description: |
+            Internal server error during HAA (downstream EBICS host, transport, or parsing). Matches the EBICS client
+            behaviour of returning HTTP 500 with a JSON body where `status` is `ERROR` and `message` carries details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HAAResponse'
+              examples:
+                haaExecutionError:
+                  summary: HAA execution failed
+                  value:
+                    ebicsUserId: "ZKB03305"
+                    status: "ERROR"
+                    message: "Failed to execute HAA: Error in executing HAA :: ZKB03305 :: …"
+                    services: []
 
   /client/ebics/v3/hac:
     post:
-      summary: HAC – Download customer acknowledgements
+      summary: HAC – Customer acknowledgements (pain.002)
       description: |
-        Returns customer acknowledgements (status of previously submitted orders) from the bank.
+        Returns order statuses (or HACs - Host Customer Acknowledgement) for the given date range.
+        EBICS 3.0 H005 **HAC** (Host Customer Acknowledgement): downloads **customer acknowledgements** as ISO 20022
+        **pain.002** (EBICS 3.0 ch.10). 
+        
+        The EBICS client parses the message and surfaces extracted **`StsRsnInf`**
+        blocks: originator name, optional **`OrgId/Othr`** identifications, **`Rsn/Cd`**, optional EBICS annex
+        **`reasonName` / `reasonDescription`**, and **`AddtlInf`** lines.
 
-        Useful for reconciling the status of BTU uploads after the fact.
+        Typical use: after **BTU**, reconcile **technical / signature** status before relying on **BTD** pain.002 PSR,
+        **C54**, **C52**, or **C53** (see BTU flow in the EBICS client API docs).
 
-        The request body is empty — `ebicsUserId` and `billerId` are resolved internally from your JWT.
+        The request body may be `{}` or include optional inclusive **`yyyy-MM-dd`** `startDate` / `endDate` (see
+        `HACRequest`); `ebicsUserId` and `billerId` are resolved internally from your JWT.
+
+        **Note:** Send **both** dates together for a historical window, or **neither** for delta / “since last HAC”
+        behaviour (bank-dependent). 
       operationId: v3Hac
       tags: [EBICS v3]
       requestBody:
@@ -972,14 +1140,244 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/HACRequest'
-            example: {}
+            examples:
+              hacActualDownload:
+                summary: Actual HAC download
+                description: Download actual HAC order statuses
+                value: {}
+              hacHistoricalDownload:
+                summary: Historical HAC download
+                description: Download historical HAC statuses for the given date range (inclusive).
+                value:
+                  startDate: "2026-04-01"
+                  endDate: "2026-04-20"
       responses:
         '200':
-          description: HAC executed successfully
+          description: |
+            HAC executed successfully — parsed **`statusReasons`** from pain.002 (may be empty if there is nothing new
+            in the requested window / delta).
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/HACResponse'
+              examples:
+                hacUnsuccessfulUploadDs0g:
+                  summary: Unsuccessful upload example (DS0G)
+                  description: Example of status chain for after pain.001 upload. Order E001 with TS01 then DS0G NotAllowedPayment (EBICS signing rights error).
+                  value:
+                    ebicsUserId: 'ZKB03305'
+                    statusReasons:
+                    - originatorName: Billte AG
+                      identifications:
+                      - id: 'ZKB03305'
+                        schemeProprietary: UserID
+                      - id: '2491234633'
+                        schemeProprietary: PartnerID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: E001
+                        schemeProprietary: OrderID
+                      - id: '2026-03-07T14:29:17Z'
+                        schemeProprietary: TimeStamp
+                      reasonCode: TS01
+                      reasonName: TransmissionSuccessful
+                      reasonDescription: The (technical) transmission of the file was successful.
+                      additionalInformation: []
+                    - originatorName: Billte AG
+                      identifications:
+                      - id: 'ZKB03305'
+                        schemeProprietary: UserID
+                      - id: '2491234633'
+                        schemeProprietary: PartnerID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: E001
+                        schemeProprietary: OrderID
+                      - id: '2026-03-07T14:29:17Z'
+                        schemeProprietary: TimeStamp
+                      reasonCode: DS0G
+                      reasonName: NotAllowedPayment
+                      reasonDescription: Signer is not allowed to sign this operation type. In EBICS this means that the user has no authorisation rights
+                      additionalInformation: []
+                hacSuccessfulUploadPain001:
+                  summary: Successful upload example
+                  description: Example of status chain after pain.001 upload (successful upload). Order AAAP statusses was TS01, DS06, DS01, DS05.
+                  value:
+                    ebicsUserId: "610358DB2"
+                    statusReasons:
+                    - originatorName: TEST Echannels
+                      identifications:
+                      - id: "610358DB2"
+                        schemeProprietary: UserID
+                      - id: "610358DB2"
+                        schemeProprietary: PartnerID
+                      - id: AAAP
+                        schemeProprietary: OrderID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: '2026-03-26T10:32:37.11'
+                        schemeProprietary: TimeStamp
+                      reasonCode: TS01
+                      reasonName: TransmissionSuccessful
+                      reasonDescription: The (technical) transmission of the file was successful.
+                      additionalInformation: []
+                    - originatorName: TEST Echannels
+                      identifications:
+                      - id: "610358DB2"
+                        schemeProprietary: UserID
+                      - id: "610358DB2"
+                        schemeProprietary: PartnerID
+                      - id: AAAP
+                        schemeProprietary: OrderID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: '2026-03-26T10:32:37.11'
+                        schemeProprietary: TimeStamp
+                      reasonCode: DS06
+                      reasonName: TransferOrder
+                      reasonDescription: The order was transferred to EDS
+                      additionalInformation: []
+                    - originatorName: TEST Echannels
+                      identifications:
+                      - id: "610358DB2"
+                        schemeProprietary: UserID
+                      - id: "610358DB2"
+                        schemeProprietary: PartnerID
+                      - id: AAAP
+                        schemeProprietary: OrderID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: '2026-03-26T10:32:37.2033333'
+                        schemeProprietary: TimeStamp
+                      reasonCode: DS01
+                      reasonName: ElectronicSignaturesCorrect
+                      reasonDescription: The Electronic Signature(s) are correct
+                      additionalInformation: []
+                    - originatorName: TEST Echannels
+                      identifications:
+                      - id: "610358DB2"
+                        schemeProprietary: UserID
+                      - id: "610358DB2"
+                        schemeProprietary: PartnerID
+                      - id: AAAP
+                        schemeProprietary: OrderID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: '2026-03-26T10:32:37.22'
+                        schemeProprietary: TimeStamp
+                      reasonCode: DS05
+                      reasonName: OrderForwardedForPostprocessing
+                      reasonDescription: The order was correct and could be forwarded for postprocessing
+                      additionalInformation: []
+                hacMixedDownloadUpload:
+                  summary: Mixed download and upload example
+                  description: Example of status chain for one download operation of pain.002 (no data available) and one upload operation of pain.001, order E000 ending up with status DS04 bank-side content rejection
+                    (unsuccessful upload).
+                  value:
+                    ebicsUserId: 'ZKB03305'
+                    statusReasons:
+                    - originatorName: Billte AG
+                      identifications:
+                      - id: 'ZKB03305'
+                        schemeProprietary: UserID
+                      - id: '2491234633'
+                        schemeProprietary: PartnerID
+                      - id: BTD
+                        schemeProprietary: AdminOrderType
+                      - id: PSR
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: ZIP
+                        schemeProprietary: ContainerType
+                      - id: pain.002
+                        schemeProprietary: MsgName
+                      - id: '2026-03-06T00:31:34Z'
+                        schemeProprietary: TimeStamp
+                      reasonCode: TD01
+                      reasonName: NoDataAvailable
+                      reasonDescription: There is no data available (for download)
+                      additionalInformation: []
+                    - originatorName: Billte AG
+                      identifications:
+                      - id: 'ZKB03305'
+                        schemeProprietary: UserID
+                      - id: '2491234633'
+                        schemeProprietary: PartnerID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: E000
+                        schemeProprietary: OrderID
+                      - id: '2026-03-06T00:45:15Z'
+                        schemeProprietary: TimeStamp
+                      reasonCode: TS01
+                      reasonName: TransmissionSuccessful
+                      reasonDescription: The (technical) transmission of the file was successful.
+                      additionalInformation: []
+                    - originatorName: Billte AG
+                      identifications:
+                      - id: 'ZKB03305'
+                        schemeProprietary: UserID
+                      - id: '2491234633'
+                        schemeProprietary: PartnerID
+                      - id: BTU
+                        schemeProprietary: AdminOrderType
+                      - id: MCT
+                        schemeProprietary: ServiceName
+                      - id: CH
+                        schemeProprietary: Scope
+                      - id: pain.001
+                        schemeProprietary: MsgName
+                      - id: E000
+                        schemeProprietary: OrderID
+                      - id: '2026-03-06T00:45:15Z'
+                        schemeProprietary: TimeStamp
+                      reasonCode: DS04
+                      reasonName: OrderRejected
+                      reasonDescription: The order was rejected by the bank side (for reasons concerning content)
+                      additionalInformation: []
         '401':
           description: |
             Unauthorized. Returned when:
@@ -999,6 +1397,37 @@ paths:
                   description: Returned when `ebicsStatus` flips off after the JWT was issued.
                   value:
                     error: "Unauthorized: billerPid is not valid or biller is not active"
+        '500':
+          description: |
+            Internal server error during HAC (downstream EBICS host, transport, or pain.002 parsing). Matches the EBICS
+            client behaviour of returning HTTP 500 with `status` = `ERROR` and `message` carrying details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HACResponse'
+              examples:
+                hacExecutionError:
+                  summary: HAC execution failed
+                  value:
+                    ebicsUserId: "ZKB03305"
+                    status: "ERROR"
+                    message: "Failed to execute HAC: Error in executing HAC :: ZKB03305 :: …"
+                    statusReasons: []
+
+  # CAMT C52/C53/C54 parse — maintained in ebics-biller-camt-api.yaml
+  "/client/ebics/v3/C52-canonical":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C52-canonical'
+  "/client/ebics/v3/C53-canonical":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C53-canonical'
+  "/client/ebics/v3/C54-canonical":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C54-canonical'
+  "/client/ebics/v3/C52-iso":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C52-iso'
+  "/client/ebics/v3/C53-iso":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C53-iso'
+  "/client/ebics/v3/C54-iso":
+    $ref: './ebics-biller-camt-api.yaml#/paths/~1client~1ebics~1v3~1C54-iso'
+
 
 tags:
   - name: Authentication

--- a/ebics-biller-camt-api.yaml
+++ b/ebics-biller-camt-api.yaml
@@ -1,0 +1,3829 @@
+---
+openapi: 3.0.3
+info:
+  title: EBICS Biller API — CAMT parse (fragment)
+  version: 1.0.0
+  description: |-
+    **Fragment** merged into the main EBICS Biller OpenAPI via `$ref` from `ebics-biller-api.yml`.
+
+    Contains CAMT **C52 / C53 / C54** `*-iso` and `*-canonical` path definitions and their schemas (`CamtBtdDerivedParseRequest`, `CamtCanonicalParseResponse` with nested `CamtCanonical*` canonical payload types, `CamtIsoParseResponse`).
+
+    `ErrorResponse` for HTTP 401 is referenced from `ebics-biller-api.yml`.
+
+    Regenerate from Java examples: `RUBYOPT='-EUTF-8:UTF-8' ruby scripts/gen_camt_parse_openapi.rb` (run from repo root `ebill-swp-redoc/`).
+paths:
+  "/client/ebics/v3/C52-canonical":
+    post:
+      summary: C52 - Download canonical shape
+      description: |-
+        Downloads intraday account statements (CAMT.052) via EBICS BTD operation and 
+        returns compact canonical JSON representation of the camt.052 content.
+
+        Main entities in the response are following:
+        ```text
+        document
+        ├── account
+        ├── balances[]
+        └── entities[]
+            └── transactions[]
+        ```
+        The response structure is unified for all camt types: `camt.052`, `camt.053` and `camt.054` and their versions: `04` and `08`.
+        The structure is universal simplification of the complex ISO20022 XML camt documentstructure, providing convinient way to use single UI layout to display all camt types and versions.
+      operationId: v3C52Canonical
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (STM, CH, camt.052, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Intraday account report request (Actual)
+                description: Camt052 v08 Statement (Actual download of not-yet downloaded
+                  files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Intraday account report request (Historical)
+                description: Camt052 v08 Statement (Historical Download for given
+                  date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-20'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+              examples:
+                camt052Canonical00104:
+                  summary: CAMT.052.001.04 — canonical JSON
+                  description: This is example of mapping a camt.052.001.04 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-052-001-04.xml
+                        originalMessageId: AAAASESS-FP-STAT001
+                        documentType: CAMT052
+                        documentId: AAAASESS-FP-RPT001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Report-level additional narrative
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        balances:
+                        - type: OPBD
+                          subType: SUB-OP-PRTRY
+                          amount: '500000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-15'
+                          availability:
+                          - amount: '250000'
+                            currency: SEK
+                            date: '2010-10-16'
+                          - amount: '100000'
+                            currency: SEK
+                            date: NBR_DAYS:2
+                        - type: CUST_CLOSING
+                          subType: INTM
+                          amount: '435678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-18'
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.052.001.04
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+                camt052Canonical00108:
+                  summary: CAMT.052.001.08 — canonical JSON
+                  description: This is example of mapping a camt.052.001.08 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-052-001-08.xml
+                        originalMessageId: AAAASESS-FP-STAT001
+                        documentType: CAMT052
+                        documentId: AAAASESS-FP-RPT001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Report-level additional narrative
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        balances:
+                        - type: OPBD
+                          subType: SUB-OP-PRTRY
+                          amount: '500000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-15'
+                          availability:
+                          - amount: '250000'
+                            currency: SEK
+                            date: '2010-10-16'
+                          - amount: '100000'
+                            currency: SEK
+                            date: NBR_DAYS:2
+                        - type: CUST_CLOSING
+                          subType: INTM
+                          amount: '435678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-18'
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.052.001.08
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            uetr: 550e8400-e29b-41d4-a716-446655440000
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            uetr: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            uetr: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+  "/client/ebics/v3/C53-canonical":
+    post:
+      summary: C53 - Download canonical shape
+      description: |-
+        Downloads end of day account statements (CAMT.053) via EBICS BTD operation and
+        returns compact canonical JSON representation of the camt.053 content.
+
+        Main entities in the response are following:
+        ```text
+        document
+        ├── account
+        ├── balances[]
+        └── entities[]
+            └── transactions[]
+        ```
+        The response structure is unified for all camt types: `camt.052`, `camt.053` and `camt.054` and their versions: `04` and `08`.
+        The structure is universal simplification of the complex ISO 20022 XML camt document structure, providing a convenient way to use a single UI layout to display all camt types and versions.
+      operationId: v3C53Canonical
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (EOP, CH, camt.053, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Daily account statement request (Actual)
+                description: Camt053 v08 Statement (Actual download of not-yet downloaded
+                  files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Daily account statement request (Historical)
+                description: Camt053 v08 Statement (Historical Download for given
+                  date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-01'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+              examples:
+                camt053Canonical00104:
+                  summary: CAMT.053.001.04 — canonical JSON
+                  description: This is example of mapping a camt.053.001.04 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-053-001-04.xml
+                        originalMessageId: AAAASESS-FP-STAT001
+                        documentType: CAMT053
+                        documentId: AAAASESS-FP-STAT001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Statement-level additional narrative
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        balances:
+                        - type: OPBD
+                          subType: SUB-OP-PRTRY
+                          amount: '500000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-15'
+                          availability:
+                          - amount: '250000'
+                            currency: SEK
+                            date: '2010-10-16'
+                          - amount: '100000'
+                            currency: SEK
+                            date: NBR_DAYS:2
+                        - type: CUST_CLOSING
+                          subType: INTM
+                          amount: '435678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-18'
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.053.001.04
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+                camt053Canonical00108:
+                  summary: CAMT.053.001.08 — canonical JSON
+                  description: This is example of mapping a camt.053.001.08 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-053-001-08.xml
+                        originalMessageId: AAAASESS-FP-STAT001
+                        documentType: CAMT053
+                        documentId: AAAASESS-FP-STAT001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Statement-level additional narrative
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        balances:
+                        - type: OPBD
+                          subType: SUB-OP-PRTRY
+                          amount: '500000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-15'
+                          availability:
+                          - amount: '250000'
+                            currency: SEK
+                            date: '2010-10-16'
+                          - amount: '100000'
+                            currency: SEK
+                            date: NBR_DAYS:2
+                        - type: CUST_CLOSING
+                          subType: INTM
+                          amount: '435678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          asOfDate: '2010-10-18'
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.053.001.08
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            uetr: 550e8400-e29b-41d4-a716-446655440000
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            uetr: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            uetr: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+  "/client/ebics/v3/C54-canonical":
+    post:
+      summary: C54 - Download canonical shape
+      description: |-
+        Downloads credit/debit notifications (CAMT.054) via EBICS BTD operation and
+        returns compact canonical JSON representation of the camt.054 content.
+
+        Main entities in the response are following:
+        ```text
+        document
+        ├── account
+        ├── balances[]
+        └── entities[]
+            └── transactions[]
+        ```
+        The response structure is unified for all camt types: `camt.052`, `camt.053` and `camt.054` and their versions: `04` and `08`.
+        The structure is universal simplification of the complex ISO 20022 XML camt document structure, providing a convenient way to use a single UI layout to display all camt types and versions.
+        For debit/credit notifications, the same layout carries notification-specific fields (for example `relatedAccount`, `transactionsSummary`) and `balances` only when the underlying message contains them.
+      operationId: v3C54Canonical
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (REP, CH, camt.054, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Credit/Debit Notifications request (Actual)
+                description: Camt054 v08 Credit/Debit Notifications (Actual download
+                  of not-yet downloaded files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Credit/Debit Notifications request (Historical)
+                description: Camt054 v08 Credit/Debit Notifications (Historical Download
+                  for given date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-01'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+              examples:
+                camt054Canonical00104:
+                  summary: CAMT.054.001.04 — canonical JSON
+                  description: This is example of mapping a camt.054.001.04 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-054-001-04.xml
+                        originalMessageId: AAAASESS-FP-N54-GRP
+                        documentType: CAMT054
+                        documentId: AAAASESS-FP-N54-001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Notification-level additional narrative for
+                          CAMT.054.001.04 rich fixture
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.054.001.04
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '3255'
+                              currency: EUR
+                            exchangeRate: 0.1085 EUR→SEK
+                        relatedAccount:
+                          othrId: NTF-RLTD-SE-8899
+                        copyDuplicateIndicator: DUPL
+                        reportingSource: SOLE
+                        transactionsSummary:
+                          totalNumberOfEntries: '3'
+                          totalSum: 335678.5
+                          totalNetEntryAmount: 64321.5
+                          totalNetCreditDebitIndicator: DBIT
+                          creditEntriesNumber: '2'
+                          creditSum: 135678.5
+                          debitEntriesNumber: '1'
+                          debitSum: 200000
+                camt054Canonical00108:
+                  summary: CAMT.054.001.08 — canonical JSON
+                  description: This is example of mapping a camt.054.001.08 to canonical
+                    JSON
+                  value:
+                    parseResult:
+                      documents:
+                      - sourceZipEntry: rich-054-001-08.xml
+                        originalMessageId: AAAASESS-FP-N54-GRP
+                        documentType: CAMT054
+                        documentId: AAAASESS-FP-N54-001
+                        electronicSequenceNumber: '42'
+                        legalSequenceNumber: '7'
+                        pagination:
+                          pageNumber: '2'
+                          lastPage: false
+                        creationDateTime: '2010-10-18T17:00:00+01:00'
+                        period:
+                          from: '2010-10-18T08:00:00+01:00'
+                          to: '2010-10-18T17:00:00+01:00'
+                        additionalInfo: Notification-level additional narrative for
+                          CAMT.054.001.08 rich fixture
+                        account:
+                          iban: SE3550000000054910000003
+                          othrId: SE-BANKDOM-5566778899
+                        accountName: Operating account FINPETROL
+                        accountOwner:
+                          name: FINPETROL
+                          partyId: 556677-8899
+                          country: SE
+                        accountCurrency: SEK
+                        accountServicerBic: AAAASESS
+                        accountServicer:
+                          bic: AAAASESS
+                          name: AAAA BANKEN
+                        entries:
+                        - entryReference: NTRY-CR-FULL-001
+                          amount: '105678.50'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: BOOK
+                          bookingStatus: camt.054.001.08
+                          isReversal: false
+                          numberOfTransactions: 1
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T13:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: PAYM
+                          bankTransactionCodeStructured:
+                            domain: PAYM
+                            family: RCDT
+                            subFamily: BOOK
+                          additionalEntryInformation: Incoming payment with full transaction
+                            details
+                          transactions:
+                          - instructionId: INSTR-SE-1001
+                            endToEndId: MUELL/FINP/RA12345
+                            uetr: 550e8400-e29b-41d4-a716-446655440000
+                            transactionId: TX-CR-SE-01
+                            clearingSystemReference: CLR-SE-556677
+                            accountServicerReference: ASR-TX-CR-001
+                            mandateId: MANDATE-DD-SE-2020
+                            checkNumber: CHQ-SE-009988
+                            amount: '105678.50'
+                            currency: SEK
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '9800.00'
+                              currency: EUR
+                            transactionAmount:
+                              amount: '105678.50'
+                              currency: SEK
+                            exchangeRate: 10.7835 EUR→SEK
+                            charges:
+                            - amount: '15.00'
+                              currency: SEK
+                              type: COMM
+                            - amount: '10.50'
+                              currency: SEK
+                              type: OURCHG
+                            counterpartyName: MUELLER GmbH
+                            counterpartyIban: DE89370400440532013000
+                            debtor:
+                              name: MUELLER GmbH
+                              iban: DE89370400440532013000
+                              partyId: DE-ORG-998877
+                              country: DE
+                              address:
+                                streetName: Hauptstrasse 5
+                                postCode: D-10115
+                                townName: Berlin
+                                country: DE
+                            ultimateDebtor:
+                              name: Ultimate Debtor AG
+                              country: AT
+                            remittanceUnstructured: Invoice MUELL-2020-88; Service
+                              period Q4
+                            remittanceStructured:
+                              reference: RF18539007547034
+                              invoicee: Invoicee Oy
+                              invoicer: Invoicer AB
+                              additionalRemittanceInformation:
+                              - Additional remittance line one
+                              - Additional remittance line two
+                            bankTransactionCodeStructured:
+                              proprietary: TX-PRTRY-CD
+                              proprietaryIssuer: AAAA
+                        - entryReference: NTRY-DB-BATCH-002
+                          amount: '200000'
+                          currency: SEK
+                          creditDebitIndicator: DBIT
+                          entryStatus: PDNG
+                          isReversal: true
+                          numberOfTransactions: 20
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T10:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: BANK-PROPR-DBIT
+                          bankTransactionCodeStructured:
+                            proprietary: BANK-PROPR-DBIT
+                            proprietaryIssuer: AAAA
+                          transactions:
+                          - endToEndId: E2E-BATCH-SAMPLE
+                            uetr: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+                            accountServicerReference: AAAASESS-FP-ACCR-01
+                            amount: '200000'
+                            currency: SEK
+                            creditDebitIndicator: DBIT
+                            counterpartyName: Supplier Consolidated AB
+                            counterpartyIban: SE7280000812790000096986
+                            creditor:
+                              name: Supplier Consolidated AB
+                              iban: SE7280000812790000096986
+                              address:
+                                streetName: Exportgatan 3
+                                townName: Göteborg
+                                country: SE
+                            ultimateCreditor:
+                              name: Ultimate Creditor Group
+                              partyId: PRVT-ULT-CDTR-01
+                              country: 'NO'
+                            remittanceUnstructured: Batch supplier payment ref FINP-0055
+                        - entryReference: NTRY-FX-003
+                          amount: '30000'
+                          currency: SEK
+                          creditDebitIndicator: CRDT
+                          entryStatus: INFO
+                          entryDetailsPresent: true
+                          bookingDateTime: '2010-10-18T15:15:00+01:00'
+                          valueDate: '2010-10-18'
+                          bankTransactionCode: TREA
+                          bankTransactionCodeStructured:
+                            domain: TREA
+                            family: '0002'
+                            subFamily: '0000'
+                          transactions:
+                          - instructionId: FP-004567-FX
+                            endToEndId: AAAASS1085FINPSS
+                            uetr: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+                            accountServicerReference: AAAASESS-FP-CONF-FX
+                            amount: '3255'
+                            currency: EUR
+                            creditDebitIndicator: CRDT
+                            instructedAmount:
+                              amount: '3255'
+                              currency: EUR
+                            exchangeRate: 0.1085 EUR→SEK
+                        relatedAccount:
+                          iban: DE89370400440532013000
+                        copyDuplicateIndicator: COPY
+                        reportingSource: INTR
+                        transactionsSummary:
+                          totalNumberOfEntries: '3'
+                          totalSum: 335678.5
+                          totalNetEntryAmount: 64321.5
+                          totalNetCreditDebitIndicator: DBIT
+                          creditEntriesNumber: '2'
+                          creditSum: 135678.5
+                          debitEntriesNumber: '1'
+                          debitSum: 200000
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtCanonicalParseResponse"
+  "/client/ebics/v3/C52-iso":
+    post:
+      summary: C52 - Download ISO shape
+      description: |-
+        Downloads CAMT.052 via EBICS BTD operation and 
+        returns compact ISO-shaped JSON representation of the camt.052 content.
+        
+        Main entities in the response are following:
+        ```text
+        Document
+        └── BkToCstmrAcctRpt[]
+            └── Rpt[]
+                └── Acct
+                └── Bal[]
+                └── Ntry[]
+                    └── NtryDtls[]
+                        └── TxDtls[]
+        ```
+        The structure and elements names eqivalents of original XML ISO20022 elements.  
+        The response structure is unified for camt.052.001.04 and camt.052.001.08.
+        The response structure is different per camt type: `camt.052`, `camt.053` and `camt.054`.
+      operationId: v3C52Iso
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (STM, CH, camt.052, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Intraday account report request (Actual)
+                description: Camt052 v08 Statement (Actual download of not-yet downloaded
+                  files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Intraday account report request (Historical)
+                description: Camt052 v08 Statement (Historical Download for given
+                  date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-20'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+              examples:
+                camt052Iso00104:
+                  summary: CAMT.052.001.04 — ISO-shaped JSON
+                  description: This is example of mapping a camt.052.001.04 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-052-001-04.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.052.001.04
+                      Document:
+                        BkToCstmrAcctRpt:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-STAT001
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: Group header additional information
+                          Rpt:
+                          - Id: AAAASESS-FP-RPT001
+                            RptPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            FrToDt:
+                              FrDtTm: '2010-10-18T08:00:00+01:00'
+                              ToDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlRptInf: Report-level additional narrative
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                                Id:
+                                  OrgId:
+                                    Othr:
+                                      Id: 556677-8899
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            Bal:
+                            - Tp:
+                                CdOrPrtry:
+                                  Cd: OPBD
+                                SubTp:
+                                  Prtry: SUB-OP-PRTRY
+                              Amt:
+                                value: '500000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-15'
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-16'
+                                Amt:
+                                  value: '250000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              - Dt:
+                                  NbOfDays: '2'
+                                Amt:
+                                  value: '100000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                            - Tp:
+                                CdOrPrtry:
+                                  Prtry: CUST_CLOSING
+                                SubTp:
+                                  Cd: INTM
+                              Amt:
+                                value: '435678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-18'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-19'
+                                Amt:
+                                  value: '105678.50'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlInfInd:
+                                MsgNmId: camt.052.001.04
+                                MsgId: BOOKING-STATUS-REF-01
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-BATCH-MSG
+                                  PmtInfId: FINP-BATCH-PMT-001
+                                  NbOfTxs: '1'
+                                TxDtls:
+                                - Refs:
+                                    AcctSvcrRef: ASR-TX-CR-001
+                                    InstrId: INSTR-SE-1001
+                                    EndToEndId: MUELL/FINP/RA12345
+                                    TxId: TX-CR-SE-01
+                                    MndtId: MANDATE-DD-SE-2020
+                                    ChqNb: CHQ-SE-009988
+                                    ClrSysRef: CLR-SE-556677
+                                  Amt:
+                                    value: '105678.50'
+                                    Ccy: SEK
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    InstdAmt:
+                                      Amt:
+                                        value: '9800.00'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        TrgtCcy: SEK
+                                        XchgRate: '10.7835'
+                                    TxAmt:
+                                      Amt:
+                                        value: '105678.50'
+                                        Ccy: SEK
+                                  Avlbty:
+                                  - Dt:
+                                      NbOfDays: '0'
+                                    Amt:
+                                      value: '105678.50'
+                                      Ccy: SEK
+                                    CdtDbtInd: CRDT
+                                  BkTxCd:
+                                    Prtry:
+                                      Cd: TX-PRTRY-CD
+                                      Issr: AAAA
+                                  Chrgs:
+                                    TtlChrgsAndTaxAmt:
+                                      value: '25.50'
+                                      Ccy: SEK
+                                    Rcrd:
+                                    - Amt:
+                                        value: '15.00'
+                                        Ccy: SEK
+                                      CdtDbtInd: DBIT
+                                      Tp:
+                                        Cd: COMM
+                                    - Amt:
+                                        value: '10.50'
+                                        Ccy: SEK
+                                      Tp:
+                                        Prtry:
+                                          Id: OURCHG
+                                          Issr: AAAA
+                                  RmtInf:
+                                    Ustrd:
+                                    - Invoice MUELL-2020-88; Service period Q4
+                                    Strd:
+                                    - CdtrRefInf:
+                                        Ref: RF18539007547034
+                                      Invcr:
+                                        Nm: Invoicer AB
+                                        PstlAdr:
+                                          AdrLine:
+                                          - Box 100
+                                          - SE-111 22 Stockholm
+                                      Invcee:
+                                        Nm: Invoicee Oy
+                                      AddtlRmtInf:
+                                      - Additional remittance line one
+                                      - Additional remittance line two
+                                  RltdPties:
+                                    Dbtr:
+                                      Nm: MUELLER GmbH
+                                      PstlAdr:
+                                        StrtNm: Hauptstrasse 5
+                                        PstCd: D-10115
+                                        TwnNm: Berlin
+                                        Ctry: DE
+                                      CtryOfRes: DE
+                                      Id:
+                                        OrgId:
+                                          Othr:
+                                            Id: DE-ORG-998877
+                                    DbtrAcct:
+                                      Id:
+                                        IBAN: DE89370400440532013000
+                                    UltmtDbtr:
+                                      Nm: Ultimate Debtor AG
+                                      CtryOfRes: AT
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-0055
+                                  PmtInfId: FINP-0055/001
+                                  NbOfTxs: '20'
+                                TxDtls:
+                                - Refs:
+                                    EndToEndId: E2E-BATCH-SAMPLE
+                                  Amt:
+                                    value: '200000'
+                                    Ccy: SEK
+                                  CdtDbtInd: DBIT
+                                  RmtInf:
+                                    Ustrd:
+                                    - Batch supplier payment ref FINP-0055
+                                  RltdPties:
+                                    Cdtr:
+                                      Nm: Supplier Consolidated AB
+                                      PstlAdr:
+                                        StrtNm: Exportgatan 3
+                                        TwnNm: Göteborg
+                                        Ctry: SE
+                                    CdtrAcct:
+                                      Id:
+                                        IBAN: SE7280000812790000096986
+                                    UltmtCdtr:
+                                      Nm: Ultimate Creditor Group
+                                      CtryOfRes: 'NO'
+                                      Id:
+                                        PrvtId:
+                                          Othr:
+                                            Id: PRVT-ULT-CDTR-01
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Cd: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+                              NtryDtls:
+                              - TxDtls:
+                                - Refs:
+                                    InstrId: FP-004567-FX
+                                    EndToEndId: AAAASS1085FINPSS
+                                  Amt:
+                                    value: '3255'
+                                    Ccy: EUR
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    CntrValAmt:
+                                      Amt:
+                                        value: '3255'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        XchgRate: '0.1085'
+                camt052Iso00108:
+                  summary: CAMT.052.001.08 — ISO-shaped JSON
+                  description: This is example of mapping a camt.052.001.08 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-052-001-08.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.052.001.08
+                      Document:
+                        BkToCstmrAcctRpt:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-STAT001
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: Group header additional information
+                          Rpt:
+                          - Id: AAAASESS-FP-RPT001
+                            RptPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            FrToDt:
+                              FrDtTm: '2010-10-18T08:00:00+01:00'
+                              ToDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlRptInf: Report-level additional narrative
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                                Id:
+                                  OrgId:
+                                    Othr:
+                                      Id: 556677-8899
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            Bal:
+                            - Tp:
+                                CdOrPrtry:
+                                  Cd: OPBD
+                                SubTp:
+                                  Prtry: SUB-OP-PRTRY
+                              Amt:
+                                value: '500000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-15'
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-16'
+                                Amt:
+                                  value: '250000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              - Dt:
+                                  NbOfDays: '2'
+                                Amt:
+                                  value: '100000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                            - Tp:
+                                CdOrPrtry:
+                                  Prtry: CUST_CLOSING
+                                SubTp:
+                                  Cd: INTM
+                              Amt:
+                                value: '435678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-18'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-19'
+                                Amt:
+                                  value: '105678.50'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlInfInd:
+                                MsgNmId: camt.052.001.08
+                                MsgId: BOOKING-STATUS-REF-01
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-BATCH-MSG
+                                  PmtInfId: FINP-BATCH-PMT-001
+                                  NbOfTxs: '1'
+                                TxDtls:
+                                - Refs:
+                                    AcctSvcrRef: ASR-TX-CR-001
+                                    InstrId: INSTR-SE-1001
+                                    EndToEndId: MUELL/FINP/RA12345
+                                    UETR: 550e8400-e29b-41d4-a716-446655440000
+                                    TxId: TX-CR-SE-01
+                                    MndtId: MANDATE-DD-SE-2020
+                                    ChqNb: CHQ-SE-009988
+                                    ClrSysRef: CLR-SE-556677
+                                  Amt:
+                                    value: '105678.50'
+                                    Ccy: SEK
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    InstdAmt:
+                                      Amt:
+                                        value: '9800.00'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        TrgtCcy: SEK
+                                        XchgRate: '10.7835'
+                                    TxAmt:
+                                      Amt:
+                                        value: '105678.50'
+                                        Ccy: SEK
+                                  Avlbty:
+                                  - Dt:
+                                      NbOfDays: '0'
+                                    Amt:
+                                      value: '105678.50'
+                                      Ccy: SEK
+                                    CdtDbtInd: CRDT
+                                  BkTxCd:
+                                    Prtry:
+                                      Cd: TX-PRTRY-CD
+                                      Issr: AAAA
+                                  Chrgs:
+                                    TtlChrgsAndTaxAmt:
+                                      value: '25.50'
+                                      Ccy: SEK
+                                    Rcrd:
+                                    - Amt:
+                                        value: '15.00'
+                                        Ccy: SEK
+                                      CdtDbtInd: DBIT
+                                      Tp:
+                                        Cd: COMM
+                                    - Amt:
+                                        value: '10.50'
+                                        Ccy: SEK
+                                      Tp:
+                                        Prtry:
+                                          Id: OURCHG
+                                          Issr: AAAA
+                                  RmtInf:
+                                    Ustrd:
+                                    - Invoice MUELL-2020-88; Service period Q4
+                                    Strd:
+                                    - CdtrRefInf:
+                                        Ref: RF18539007547034
+                                      Invcr:
+                                        Nm: Invoicer AB
+                                        PstlAdr:
+                                          AdrLine:
+                                          - Box 100
+                                          - SE-111 22 Stockholm
+                                      Invcee:
+                                        Nm: Invoicee Oy
+                                      AddtlRmtInf:
+                                      - Additional remittance line one
+                                      - Additional remittance line two
+                                  RltdPties:
+                                    Dbtr:
+                                      Nm: MUELLER GmbH
+                                      PstlAdr:
+                                        StrtNm: Hauptstrasse 5
+                                        PstCd: D-10115
+                                        TwnNm: Berlin
+                                        Ctry: DE
+                                      CtryOfRes: DE
+                                      Id:
+                                        OrgId:
+                                          Othr:
+                                            Id: DE-ORG-998877
+                                    DbtrAcct:
+                                      Id:
+                                        IBAN: DE89370400440532013000
+                                    UltmtDbtr:
+                                      Nm: Ultimate Debtor AG
+                                      CtryOfRes: AT
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-0055
+                                  PmtInfId: FINP-0055/001
+                                  NbOfTxs: '20'
+                                TxDtls:
+                                - Refs:
+                                    EndToEndId: E2E-BATCH-SAMPLE
+                                    UETR: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+                                  Amt:
+                                    value: '200000'
+                                    Ccy: SEK
+                                  CdtDbtInd: DBIT
+                                  RmtInf:
+                                    Ustrd:
+                                    - Batch supplier payment ref FINP-0055
+                                  RltdPties:
+                                    Cdtr:
+                                      Nm: Supplier Consolidated AB
+                                      PstlAdr:
+                                        StrtNm: Exportgatan 3
+                                        TwnNm: Göteborg
+                                        Ctry: SE
+                                    CdtrAcct:
+                                      Id:
+                                        IBAN: SE7280000812790000096986
+                                    UltmtCdtr:
+                                      Nm: Ultimate Creditor Group
+                                      CtryOfRes: 'NO'
+                                      Id:
+                                        PrvtId:
+                                          Othr:
+                                            Id: PRVT-ULT-CDTR-01
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Prtry: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+                              NtryDtls:
+                              - TxDtls:
+                                - Refs:
+                                    InstrId: FP-004567-FX
+                                    EndToEndId: AAAASS1085FINPSS
+                                    UETR: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+                                  Amt:
+                                    value: '3255'
+                                    Ccy: EUR
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    CntrValAmt:
+                                      Amt:
+                                        value: '3255'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        XchgRate: '0.1085'
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+  "/client/ebics/v3/C53-iso":
+    post:
+      summary: C53 - Download ISO shape
+      description: |-
+        Downloads end of day account statements (CAMT.053) via EBICS BTD operation and
+        returns ISO-shaped JSON representation of the camt.053 content.
+
+        Main entities in the response are following:
+        ```text
+        Document
+        └── BkToCstmrStmt
+            └── Stmt[]
+                └── Acct
+                └── Bal[]
+                └── Ntry[]
+                    └── NtryDtls[]
+                        └── TxDtls[]
+        ```
+        The structure and element names are equivalents of the original XML ISO 20022 elements.
+        The response structure is unified for camt.053.001.04 and camt.053.001.08.
+        The response structure is different per camt type: `camt.052`, `camt.053` and `camt.054`.
+      operationId: v3C53Iso
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (EOP, CH, camt.053, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Daily account statement request (Actual)
+                description: Camt053 v08 Statement (Actual download of not-yet downloaded
+                  files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Daily account statement request (Historical)
+                description: Camt053 v08 Statement (Historical Download for given
+                  date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-01'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+              examples:
+                camt053Iso00104:
+                  summary: CAMT.053.001.04 — ISO-shaped JSON
+                  description: This is example of mapping a camt.053.001.04 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-053-001-04.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.053.001.04
+                      Document:
+                        BkToCstmrStmt:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-STAT001
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: Group header additional information
+                          Stmt:
+                          - Id: AAAASESS-FP-STAT001
+                            StmtPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlStmtInf: Statement-level additional narrative
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                                Id:
+                                  OrgId:
+                                    Othr:
+                                      Id: 556677-8899
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            Bal:
+                            - Tp:
+                                CdOrPrtry:
+                                  Cd: OPBD
+                                SubTp:
+                                  Prtry: SUB-OP-PRTRY
+                              Amt:
+                                value: '500000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-15'
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-16'
+                                Amt:
+                                  value: '250000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              - Dt:
+                                  NbOfDays: '2'
+                                Amt:
+                                  value: '100000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                            - Tp:
+                                CdOrPrtry:
+                                  Prtry: CUST_CLOSING
+                                SubTp:
+                                  Cd: INTM
+                              Amt:
+                                value: '435678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-18'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-19'
+                                Amt:
+                                  value: '105678.50'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlInfInd:
+                                MsgNmId: camt.053.001.04
+                                MsgId: BOOKING-STATUS-REF-01
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-BATCH-MSG
+                                  PmtInfId: FINP-BATCH-PMT-001
+                                  NbOfTxs: '1'
+                                TxDtls:
+                                - Refs:
+                                    AcctSvcrRef: ASR-TX-CR-001
+                                    InstrId: INSTR-SE-1001
+                                    EndToEndId: MUELL/FINP/RA12345
+                                    TxId: TX-CR-SE-01
+                                    MndtId: MANDATE-DD-SE-2020
+                                    ChqNb: CHQ-SE-009988
+                                    ClrSysRef: CLR-SE-556677
+                                  Amt:
+                                    value: '105678.50'
+                                    Ccy: SEK
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    InstdAmt:
+                                      Amt:
+                                        value: '9800.00'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        TrgtCcy: SEK
+                                        XchgRate: '10.7835'
+                                    TxAmt:
+                                      Amt:
+                                        value: '105678.50'
+                                        Ccy: SEK
+                                  Avlbty:
+                                  - Dt:
+                                      NbOfDays: '0'
+                                    Amt:
+                                      value: '105678.50'
+                                      Ccy: SEK
+                                    CdtDbtInd: CRDT
+                                  BkTxCd:
+                                    Prtry:
+                                      Cd: TX-PRTRY-CD
+                                      Issr: AAAA
+                                  Chrgs:
+                                    TtlChrgsAndTaxAmt:
+                                      value: '25.50'
+                                      Ccy: SEK
+                                    Rcrd:
+                                    - Amt:
+                                        value: '15.00'
+                                        Ccy: SEK
+                                      CdtDbtInd: DBIT
+                                      Tp:
+                                        Cd: COMM
+                                    - Amt:
+                                        value: '10.50'
+                                        Ccy: SEK
+                                      Tp:
+                                        Prtry:
+                                          Id: OURCHG
+                                          Issr: AAAA
+                                  RmtInf:
+                                    Ustrd:
+                                    - Invoice MUELL-2020-88; Service period Q4
+                                    Strd:
+                                    - CdtrRefInf:
+                                        Ref: RF18539007547034
+                                      Invcr:
+                                        Nm: Invoicer AB
+                                        PstlAdr:
+                                          AdrLine:
+                                          - Box 100
+                                          - SE-111 22 Stockholm
+                                      Invcee:
+                                        Nm: Invoicee Oy
+                                      AddtlRmtInf:
+                                      - Additional remittance line one
+                                      - Additional remittance line two
+                                  RltdPties:
+                                    Dbtr:
+                                      Nm: MUELLER GmbH
+                                      PstlAdr:
+                                        StrtNm: Hauptstrasse 5
+                                        PstCd: D-10115
+                                        TwnNm: Berlin
+                                        Ctry: DE
+                                      CtryOfRes: DE
+                                      Id:
+                                        OrgId:
+                                          Othr:
+                                            Id: DE-ORG-998877
+                                    DbtrAcct:
+                                      Id:
+                                        IBAN: DE89370400440532013000
+                                    UltmtDbtr:
+                                      Nm: Ultimate Debtor AG
+                                      CtryOfRes: AT
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-0055
+                                  PmtInfId: FINP-0055/001
+                                  NbOfTxs: '20'
+                                TxDtls:
+                                - Refs:
+                                    EndToEndId: E2E-BATCH-SAMPLE
+                                  Amt:
+                                    value: '200000'
+                                    Ccy: SEK
+                                  CdtDbtInd: DBIT
+                                  RmtInf:
+                                    Ustrd:
+                                    - Batch supplier payment ref FINP-0055
+                                  RltdPties:
+                                    Cdtr:
+                                      Nm: Supplier Consolidated AB
+                                      PstlAdr:
+                                        StrtNm: Exportgatan 3
+                                        TwnNm: Göteborg
+                                        Ctry: SE
+                                    CdtrAcct:
+                                      Id:
+                                        IBAN: SE7280000812790000096986
+                                    UltmtCdtr:
+                                      Nm: Ultimate Creditor Group
+                                      CtryOfRes: 'NO'
+                                      Id:
+                                        PrvtId:
+                                          Othr:
+                                            Id: PRVT-ULT-CDTR-01
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Cd: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+                              NtryDtls:
+                              - TxDtls:
+                                - Refs:
+                                    InstrId: FP-004567-FX
+                                    EndToEndId: AAAASS1085FINPSS
+                                  Amt:
+                                    value: '3255'
+                                    Ccy: EUR
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    CntrValAmt:
+                                      Amt:
+                                        value: '3255'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        XchgRate: '0.1085'
+                camt053Iso00108:
+                  summary: CAMT.053.001.08 — ISO-shaped JSON
+                  description: This is example of mapping a camt.053.001.08 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-053-001-08.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.053.001.08
+                      Document:
+                        BkToCstmrStmt:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-STAT001
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: Group header additional information
+                          Stmt:
+                          - Id: AAAASESS-FP-STAT001
+                            StmtPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlStmtInf: Statement-level additional narrative
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                                Id:
+                                  OrgId:
+                                    Othr:
+                                      Id: 556677-8899
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            Bal:
+                            - Tp:
+                                CdOrPrtry:
+                                  Cd: OPBD
+                                SubTp:
+                                  Prtry: SUB-OP-PRTRY
+                              Amt:
+                                value: '500000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-15'
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-16'
+                                Amt:
+                                  value: '250000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              - Dt:
+                                  NbOfDays: '2'
+                                Amt:
+                                  value: '100000'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                            - Tp:
+                                CdOrPrtry:
+                                  Prtry: CUST_CLOSING
+                                SubTp:
+                                  Cd: INTM
+                              Amt:
+                                value: '435678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Dt:
+                                Dt: '2010-10-18'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              Avlbty:
+                              - Dt:
+                                  ActlDt: '2010-10-19'
+                                Amt:
+                                  value: '105678.50'
+                                  Ccy: SEK
+                                CdtDbtInd: CRDT
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlInfInd:
+                                MsgNmId: camt.053.001.08
+                                MsgId: BOOKING-STATUS-REF-01
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-BATCH-MSG
+                                  PmtInfId: FINP-BATCH-PMT-001
+                                  NbOfTxs: '1'
+                                TxDtls:
+                                - Refs:
+                                    AcctSvcrRef: ASR-TX-CR-001
+                                    InstrId: INSTR-SE-1001
+                                    EndToEndId: MUELL/FINP/RA12345
+                                    UETR: 550e8400-e29b-41d4-a716-446655440000
+                                    TxId: TX-CR-SE-01
+                                    MndtId: MANDATE-DD-SE-2020
+                                    ChqNb: CHQ-SE-009988
+                                    ClrSysRef: CLR-SE-556677
+                                  Amt:
+                                    value: '105678.50'
+                                    Ccy: SEK
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    InstdAmt:
+                                      Amt:
+                                        value: '9800.00'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        TrgtCcy: SEK
+                                        XchgRate: '10.7835'
+                                    TxAmt:
+                                      Amt:
+                                        value: '105678.50'
+                                        Ccy: SEK
+                                  Avlbty:
+                                  - Dt:
+                                      NbOfDays: '0'
+                                    Amt:
+                                      value: '105678.50'
+                                      Ccy: SEK
+                                    CdtDbtInd: CRDT
+                                  BkTxCd:
+                                    Prtry:
+                                      Cd: TX-PRTRY-CD
+                                      Issr: AAAA
+                                  Chrgs:
+                                    TtlChrgsAndTaxAmt:
+                                      value: '25.50'
+                                      Ccy: SEK
+                                    Rcrd:
+                                    - Amt:
+                                        value: '15.00'
+                                        Ccy: SEK
+                                      CdtDbtInd: DBIT
+                                      Tp:
+                                        Cd: COMM
+                                    - Amt:
+                                        value: '10.50'
+                                        Ccy: SEK
+                                      Tp:
+                                        Prtry:
+                                          Id: OURCHG
+                                          Issr: AAAA
+                                  RmtInf:
+                                    Ustrd:
+                                    - Invoice MUELL-2020-88; Service period Q4
+                                    Strd:
+                                    - CdtrRefInf:
+                                        Ref: RF18539007547034
+                                      Invcr:
+                                        Nm: Invoicer AB
+                                        PstlAdr:
+                                          AdrLine:
+                                          - Box 100
+                                          - SE-111 22 Stockholm
+                                      Invcee:
+                                        Nm: Invoicee Oy
+                                      AddtlRmtInf:
+                                      - Additional remittance line one
+                                      - Additional remittance line two
+                                  RltdPties:
+                                    Dbtr:
+                                      Nm: MUELLER GmbH
+                                      PstlAdr:
+                                        StrtNm: Hauptstrasse 5
+                                        PstCd: D-10115
+                                        TwnNm: Berlin
+                                        Ctry: DE
+                                      CtryOfRes: DE
+                                      Id:
+                                        OrgId:
+                                          Othr:
+                                            Id: DE-ORG-998877
+                                    DbtrAcct:
+                                      Id:
+                                        IBAN: DE89370400440532013000
+                                    UltmtDbtr:
+                                      Nm: Ultimate Debtor AG
+                                      CtryOfRes: AT
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                              NtryDtls:
+                              - Btch:
+                                  MsgId: FINP-0055
+                                  PmtInfId: FINP-0055/001
+                                  NbOfTxs: '20'
+                                TxDtls:
+                                - Refs:
+                                    EndToEndId: E2E-BATCH-SAMPLE
+                                    UETR: 6ba7b810-9dad-11d1-80b4-00c04fd430c8
+                                  Amt:
+                                    value: '200000'
+                                    Ccy: SEK
+                                  CdtDbtInd: DBIT
+                                  RmtInf:
+                                    Ustrd:
+                                    - Batch supplier payment ref FINP-0055
+                                  RltdPties:
+                                    Cdtr:
+                                      Nm: Supplier Consolidated AB
+                                      PstlAdr:
+                                        StrtNm: Exportgatan 3
+                                        TwnNm: Göteborg
+                                        Ctry: SE
+                                    CdtrAcct:
+                                      Id:
+                                        IBAN: SE7280000812790000096986
+                                    UltmtCdtr:
+                                      Nm: Ultimate Creditor Group
+                                      CtryOfRes: 'NO'
+                                      Id:
+                                        PrvtId:
+                                          Othr:
+                                            Id: PRVT-ULT-CDTR-01
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Prtry: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+                              NtryDtls:
+                              - TxDtls:
+                                - Refs:
+                                    InstrId: FP-004567-FX
+                                    EndToEndId: AAAASS1085FINPSS
+                                    UETR: 7c9e6679-7425-40de-944b-e07fc1f90ae7
+                                  Amt:
+                                    value: '3255'
+                                    Ccy: EUR
+                                  CdtDbtInd: CRDT
+                                  AmtDtls:
+                                    CntrValAmt:
+                                      Amt:
+                                        value: '3255'
+                                        Ccy: EUR
+                                      CcyXchg:
+                                        SrcCcy: EUR
+                                        XchgRate: '0.1085'
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+  "/client/ebics/v3/C54-iso":
+    post:
+      summary: C54 - Download ISO shape
+      description: |-
+        Downloads credit/debit notifications (CAMT.054) via EBICS BTD operation and
+        returns ISO-shaped JSON representation of the camt.054 content.
+
+        Main entities in the response are following:
+        ```text
+        Document
+        └── BkToCstmrDbtCdtNtfctn
+            └── Ntfctn[]
+                └── Acct
+                └── RltdAcct
+                └── TxsSummry
+                └── Ntry[]
+                    └── NtryDtls[]
+                        └── TxDtls[]
+        ```
+        The structure and element names are equivalents of the original XML ISO 20022 elements.
+        The response structure is unified for camt.054.001.04 and camt.054.001.08.
+        The response structure is different per camt type: `camt.052`, `camt.053` and `camt.054`.      operationId: v3C54Iso
+      tags:
+      - EBICS v3
+      requestBody:
+        required: true
+        description: 'Minimal payloads omit serviceName, scope, msgName, msgNameVersion,
+          containerType — defaults apply (REP, CH, camt.054, 08, ZIP). Actual vs historical
+          download follows the same rule as BTD: without dates = actual; with startDate/endDate
+          = historical.'
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CamtBtdDerivedParseRequest"
+            examples:
+              actualMinimal:
+                summary: Credit/Debit Notifications request (Actual)
+                description: Camt054 v08 Credit/Debit Notifications (Actual download
+                  of not-yet downloaded files from bank.)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+              historicalMinimal:
+                summary: Credit/Debit Notifications request (Historical)
+                description: Camt054 v08 Credit/Debit Notifications (Historical Download
+                  for given date range)
+                value:
+                  ebicsUserId: ZKB03305
+                  billerId: billte-ch
+                  startDate: '2026-04-01'
+                  endDate: '2026-04-20'
+      responses:
+        '200':
+          description: Parsed successfully or BTD returned with error payload
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+              examples:
+                camt054Iso00104:
+                  summary: CAMT.054.001.04 — ISO-shaped JSON
+                  description: This is example of mapping a camt.054.001.04 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-054-001-04.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.054.001.04
+                      Document:
+                        BkToCstmrDbtCdtNtfctn:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-N54-GRP
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: CAMT054 group header additional information
+                          Ntfctn:
+                          - Id: AAAASESS-FP-N54-001
+                            NtfctnPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            FrToDt:
+                              FrDtTm: '2010-10-18T08:00:00+01:00'
+                              ToDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlNtfctnInf: Notification-level additional narrative
+                              for CAMT.054.001.04 rich fixture
+                            CpyDplctInd: DUPL
+                            RptgSrc:
+                              Cd: SOLE
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            RltdAcct:
+                              Id:
+                                Othr:
+                                  Id: NTF-RLTD-SE-8899
+                            TxsSummry:
+                              TtlNtries:
+                                NbOfNtries: '3'
+                                Sum: '335678.50'
+                                TtlNetNtry:
+                                  Amt: '64321.50'
+                                  CdtDbtInd: DBIT
+                              TtlCdtNtries:
+                                NbOfNtries: '2'
+                                Sum: '135678.50'
+                              TtlDbtNtries:
+                                NbOfNtries: '1'
+                                Sum: '200000'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Cd: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+                camt054Iso00108:
+                  summary: CAMT.054.001.08 — ISO-shaped JSON
+                  description: This is example of mapping a camt.054.001.08 to ISO-shaped
+                    JSON
+                  value:
+                    files:
+                    - zipEntryName: rich-054-001-08.xml
+                      schemaNamespace: urn:iso:std:iso:20022:tech:xsd:camt.054.001.08
+                      Document:
+                        BkToCstmrDbtCdtNtfctn:
+                          GrpHdr:
+                            MsgId: AAAASESS-FP-N54-GRP
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlInf: CAMT054 group header additional information
+                          Ntfctn:
+                          - Id: AAAASESS-FP-N54-001
+                            NtfctnPgntn:
+                              PgNb: '2'
+                              LastPgInd: false
+                            ElctrncSeqNb: '42'
+                            LglSeqNb: '7'
+                            CreDtTm: '2010-10-18T17:00:00+01:00'
+                            FrToDt:
+                              FrDtTm: '2010-10-18T08:00:00+01:00'
+                              ToDtTm: '2010-10-18T17:00:00+01:00'
+                            AddtlNtfctnInf: Notification-level additional narrative
+                              for CAMT.054.001.08 rich fixture
+                            CpyDplctInd: COPY
+                            RptgSrc:
+                              Prtry: INTR
+                            Acct:
+                              Id:
+                                IBAN: SE3550000000054910000003
+                                Othr:
+                                  Id: SE-BANKDOM-5566778899
+                              Ccy: SEK
+                              Nm: Operating account FINPETROL
+                              Ownr:
+                                Nm: FINPETROL
+                                PstlAdr:
+                                  StrtNm: Industrigatan 12
+                                  PstCd: SE-11151
+                                  TwnNm: Stockholm
+                                  Ctry: SE
+                                CtryOfRes: SE
+                              Svcr:
+                                FinInstnId:
+                                  BICFI: AAAASESS
+                                  Nm: AAAA BANKEN
+                                  PstlAdr:
+                                    Ctry: SE
+                            RltdAcct:
+                              Id:
+                                IBAN: DE89370400440532013000
+                            TxsSummry:
+                              TtlNtries:
+                                NbOfNtries: '3'
+                                Sum: '335678.50'
+                                TtlNetNtry:
+                                  Amt: '64321.50'
+                                  CdtDbtInd: DBIT
+                              TtlCdtNtries:
+                                NbOfNtries: '2'
+                                Sum: '135678.50'
+                              TtlDbtNtries:
+                                NbOfNtries: '1'
+                                Sum: '200000'
+                            Ntry:
+                            - NtryRef: NTRY-CR-FULL-001
+                              Amt:
+                                value: '105678.50'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              RvslInd: false
+                              Sts:
+                                Cd: BOOK
+                              BookgDt:
+                                DtTm: '2010-10-18T13:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CN_98765/01
+                              BkTxCd:
+                                Domn:
+                                  Cd: PAYM
+                                  Fmly:
+                                    Cd: RCDT
+                                    SubFmlyCd: BOOK
+                              AddtlNtryInf: Incoming payment with full transaction
+                                details
+                            - NtryRef: NTRY-DB-BATCH-002
+                              Amt:
+                                value: '200000'
+                                Ccy: SEK
+                              CdtDbtInd: DBIT
+                              RvslInd: true
+                              Sts:
+                                Cd: PDNG
+                              BookgDt:
+                                DtTm: '2010-10-18T10:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-ACCR-01
+                              BkTxCd:
+                                Prtry:
+                                  Cd: BANK-PROPR-DBIT
+                                  Issr: AAAA
+                            - NtryRef: NTRY-FX-003
+                              Amt:
+                                value: '30000'
+                                Ccy: SEK
+                              CdtDbtInd: CRDT
+                              Sts:
+                                Prtry: INFO
+                              BookgDt:
+                                DtTm: '2010-10-18T15:15:00+01:00'
+                              ValDt:
+                                Dt: '2010-10-18'
+                              AcctSvcrRef: AAAASESS-FP-CONF-FX
+                              BkTxCd:
+                                Domn:
+                                  Cd: TREA
+                                  Fmly:
+                                    Cd: '0002'
+                                    SubFmlyCd: '0000'
+        '401':
+          description: |-
+            Unauthorized. Returned when:
+            - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+            - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+          content:
+            application/json:
+              schema:
+                "$ref": "ebics-biller-api.yml#/components/schemas/ErrorResponse"
+              examples:
+                missingEbicsScope:
+                  summary: JWT is missing the EBICS scope
+                  value:
+                    error: 'Unauthorized: missing EBICS scope'
+                ebicsStatusInactive:
+                  summary: Biller is no longer EBICS-active
+                  description: Returned when `ebicsStatus` flips off after the JWT
+                    was issued.
+                  value:
+                    error: 'Unauthorized: billerPid is not valid or biller is not
+                      active'
+        '500':
+          description: Unexpected server error or BTD error payload (`status` = `ERROR`).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CamtIsoParseResponse"
+components:
+  schemas:
+    CamtBtdDerivedParseRequest:
+      type: object
+      description: |-
+        Request body for CAMT C52/C53/C54 **ISO** or **canonical** parse operations (mirrors EBICS client `BaseBTDRequest` / `C52Request` / `C53Request` / `C54Request`).
+
+        **Defaults when omitted** depend on the order type (see each path):
+        - **C52**: `serviceName` STM, `scope` CH, `msgName` camt.052, `msgNameVersion` 08, `containerType` ZIP
+        - **C53**: `serviceName` EOP, `scope` CH, `msgName` camt.053, `msgNameVersion` 08, `containerType` ZIP
+        - **C54**: `serviceName` REP, `scope` CH, `msgName` camt.054, `msgNameVersion` 08, `containerType` ZIP
+
+        **Actual vs historical**: same rule as BTD — omit both dates for *actual* (not-yet-downloaded) data; send `startDate` and `endDate` together for a historical window (`yyyy-MM-dd`).
+      properties:
+        requestId:
+          type: string
+          nullable: true
+          description: Optional correlation id; often set server-side.
+        ebicsUserId:
+          type: string
+          description: EBICS user id (direct EBICS client). When proxied through eBillGuardian,
+            this may be resolved from the JWT.
+          example: ZKB03305
+        billerId:
+          type: string
+          description: Biller tenant id (direct client). May be resolved from JWT
+            when proxied.
+          example: billte-ch
+        startDate:
+          type: string
+          format: date
+          nullable: true
+          description: Historical range start (inclusive).
+        endDate:
+          type: string
+          format: date
+          nullable: true
+          description: Historical range end (inclusive).
+        serviceName:
+          type: string
+          nullable: true
+          description: BTF service name (defaults per order type if omitted).
+        scope:
+          type: string
+          nullable: true
+          description: BTF scope (default CH).
+        msgName:
+          type: string
+          nullable: true
+          description: ISO message name (default camt.052 / .053 / .054 per path).
+        msgNameVersion:
+          type: string
+          nullable: true
+          description: Message version (default 08).
+        msgNameFormat:
+          type: string
+          nullable: true
+          description: Message format (default XML in client).
+        containerType:
+          type: string
+          nullable: true
+          description: Container type (default ZIP).
+    CamtCanonicalPostalAddress:
+      type: object
+      description: |-
+        Flattened postal address (`CanonicalPostalAddress`). Source: ISO 20022 `PstlAdr` on party elements
+        (e.g. `…/RltdPties/Dbtr/Pty/PstlAdr`, `…/Cdtr/Pty/PstlAdr` under `TxDtls`; v04/v08 type names differ in XSD).
+      properties:
+        department:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/Dept`.
+        subDepartment:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/SubDept`.
+        streetName:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/StrtNm`.
+        buildingNumber:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/BldgNb`.
+        postCode:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/PstCd`.
+        townName:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/TwnNm`.
+        countrySubdivision:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/CtrySubDvsn` (v08 also maps `DstrctNm` when `CtrySubDvsn` absent).
+        country:
+          type: string
+          nullable: true
+          description: ISO `PstlAdr/Ctry`.
+        addressLines:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: ISO `PstlAdr/AdrLine` (repeated).
+    CamtCanonicalParty:
+      type: object
+      description: |-
+        Debtor/creditor (or ultimate) party projection (`CanonicalParty`). Source: `TxDtls/RltdPties` —
+        **CAMT.052/053/054** `Dbtr` / `Cdtr` / `UltmtDbtr` / `UltmtCdtr` with nested `Pty` or `Agt` and optional `DbtrAcct` / `CdtrAcct` (v08 `Party40Choice` + `CashAccount38`; v04 `PartyIdentification43` + `CashAccount24`).
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: ISO `…/Pty/Nm` (v08) or `…/Dbtr|Cdtr|…/Nm` (v04 direct party).
+        iban:
+          type: string
+          nullable: true
+          description: ISO `…/DbtrAcct|CdtrAcct/Id/IBAN` when account is present.
+        bic:
+          type: string
+          nullable: true
+          description: ISO `…/Agt/FinInstnId/BICFI` when party is agent branch (v08 `Party40Choice/Agt`).
+        partyId:
+          type: string
+          nullable: true
+          description: ISO flattened from `…/Pty/Id` (`OrgId/Othr/Id` or `PrvtId/Othr/Id`, v08/v04).
+        country:
+          type: string
+          nullable: true
+          description: ISO `…/Pty/CtryOfRes`.
+        address:
+          nullable: true
+          description: ISO `…/Pty/PstlAdr`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalPostalAddress'
+    CamtCanonicalStructuredRemittance:
+      type: object
+      description: |-
+        First structured remittance slice (`CanonicalStructuredRemittance`). Source: **CAMT.052/053/054** `TxDtls/RmtInf/Strd` (first `Strd` entry only in mapper).
+      properties:
+        reference:
+          type: string
+          nullable: true
+          description: ISO `Strd/CdtrRefInf/Ref`.
+        invoicee:
+          type: string
+          nullable: true
+          description: ISO `Strd/Invcee/Nm`.
+        invoicer:
+          type: string
+          nullable: true
+          description: ISO `Strd/Invcr/Nm`.
+        additionalRemittanceInformation:
+          type: array
+          items:
+            type: string
+          nullable: true
+          description: ISO `Strd/AddtlRmtInf` (repeated).
+    CamtCanonicalBankTransactionCode:
+      type: object
+      description: |-
+        Bank transaction code breakdown (`CanonicalBankTransactionCode`). Source: **CAMT.052/053/054**
+        `Ntry/BkTxCd` (entry-level) or `TxDtls/BkTxCd` (transaction-level) — ISO `BkTxCd` (`Domn`/`Prtry` structure).
+      properties:
+        domain:
+          type: string
+          nullable: true
+          description: ISO `BkTxCd/Domn/Cd`.
+        family:
+          type: string
+          nullable: true
+          description: ISO `BkTxCd/Domn/Fmly/Cd`.
+        subFamily:
+          type: string
+          nullable: true
+          description: ISO `BkTxCd/Domn/Fmly/SubFmlyCd`.
+        proprietary:
+          type: string
+          nullable: true
+          description: ISO `BkTxCd/Prtry/Cd`.
+        proprietaryIssuer:
+          type: string
+          nullable: true
+          description: ISO `BkTxCd/Prtry/Issr`.
+    CamtCanonicalMonetaryAmount:
+      type: object
+      description: |-
+        Amount with currency (`CanonicalMonetaryAmount`). Source: **CAMT.052/053/054** `TxDtls/AmtDtls/InstdAmt` or `TxDtls/AmtDtls/TxAmt`
+        (ISO `AmountAndCurrencyExchangeDetails3/Amt` value + `Ccy`).
+      properties:
+        amount:
+          type: string
+          nullable: true
+          description: ISO `Amt/Value` (mapped as decimal string in JSON).
+        currency:
+          type: string
+          nullable: true
+          description: ISO `Amt/Ccy`.
+    CamtCanonicalCharge:
+      type: object
+      description: |-
+        One charge record (`CanonicalCharge`). Source: **CAMT.052/053/054** `TxDtls/Chrgs/Rcrd` (ISO `Charges*` record `Amt`, `Tp`).
+      properties:
+        amount:
+          type: string
+          nullable: true
+          description: ISO `Chrgs/Rcrd/Amt/Value`.
+        currency:
+          type: string
+          nullable: true
+          description: ISO `Chrgs/Rcrd/Amt/Ccy`.
+        type:
+          type: string
+          nullable: true
+          description: ISO `Chrgs/Rcrd/Tp` (`Cd` or `Prtry/Id`).
+    CamtCanonicalTransaction:
+      type: object
+      description: |-
+        Single transaction under an entry (`CanonicalTransaction`). Source: **CAMT.052/053/054**
+        `Ntry/NtryDtls/TxDtls` (flattened from all `NtryDtls` for that `Ntry`). References from `TxDtls/Refs`;
+        counterparties from `TxDtls/RltdPties` (see mapper `counterparty*` for `counterparty*` convenience fields).
+      properties:
+        instructionId:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/InstrId`.
+        endToEndId:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/EndToEndId` (v08 `TransactionReferences6`; v04 `TransactionReferences3` — same tag).
+        uetr:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/UETR` (**CAMT.052/053/054** v08 only; absent on v04 `TransactionReferences3` in mapper).
+        transactionId:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/TxId`.
+        clearingSystemReference:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/ClrSysRef`.
+        accountServicerReference:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/AcctSvcrRef`, else fallback to entry-level `Ntry/AcctSvcrRef`.
+        mandateId:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/MndtId`.
+        checkNumber:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Refs/ChqNb`.
+        amount:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Amt` (`ActiveOrHistoricCurrencyAndAmount` value).
+        currency:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/Amt/@Ccy`.
+        creditDebitIndicator:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/CdtDbtInd`.
+        instructedAmount:
+          nullable: true
+          description: ISO `TxDtls/AmtDtls/InstdAmt`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalMonetaryAmount'
+        transactionAmount:
+          nullable: true
+          description: ISO `TxDtls/AmtDtls/TxAmt`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalMonetaryAmount'
+        exchangeRate:
+          type: string
+          nullable: true
+          description: ISO derived from `TxDtls/AmtDtls` — first non-null `InstdAmt/CcyXchg` or `TxAmt/CcyXchg` (`XchgRate`, `SrcCcy`, `TrgtCcy`) formatted as a single string.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalCharge'
+          nullable: true
+          description: ISO `TxDtls/Chrgs` (`Rcrd` list).
+        counterpartyName:
+          type: string
+          nullable: true
+          description: |-
+            Convenience field from `RltdPties`: for **credit** entry (`Ntry/CdtDbtInd` = CRDT) uses `Dbtr`/`DbtrAcct`;
+            for **debit** uses `Cdtr`/`CdtrAcct` (`Nm` / `Pty/Nm` or agent BIC).
+        counterpartyIban:
+          type: string
+          nullable: true
+          description: Convenience — IBAN from chosen counterparty account (`DbtrAcct` or `CdtrAcct` `Id/IBAN`).
+        counterpartyBic:
+          type: string
+          nullable: true
+          description: Convenience — BIC from `RltdPties/.../Agt/FinInstnId/BICFI` when party is agent (v08).
+        debtor:
+          nullable: true
+          description: ISO `TxDtls/RltdPties/Dbtr` + `DbtrAcct`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalParty'
+        creditor:
+          nullable: true
+          description: ISO `TxDtls/RltdPties/Cdtr` + `CdtrAcct`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalParty'
+        ultimateDebtor:
+          nullable: true
+          description: ISO `TxDtls/RltdPties/UltmtDbtr`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalParty'
+        ultimateCreditor:
+          nullable: true
+          description: ISO `TxDtls/RltdPties/UltmtCdtr`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalParty'
+        remittanceUnstructured:
+          type: string
+          nullable: true
+          description: ISO `TxDtls/RmtInf/Ustrd` (multiple lines joined with `"; "`).
+        remittanceStructured:
+          nullable: true
+          description: ISO `TxDtls/RmtInf/Strd` (first element only).
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalStructuredRemittance'
+        bankTransactionCodeStructured:
+          nullable: true
+          description: ISO `TxDtls/BkTxCd`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalBankTransactionCode'
+    CamtCanonicalBalanceAvailability:
+      type: object
+      description: |-
+        One projected cash availability row (`CanonicalBalanceAvailability`). Source: `Bal/Avlbty`
+        (**CAMT.052/053** only; not used on 054 in this mapper) — v08 `CashAvailability1`; v04 `CashBalanceAvailability2`; `Amt` + `Dt` (`ActlDt` or encoded `NbOfDays`).
+      properties:
+        amount:
+          type: string
+          nullable: true
+          description: ISO `Bal/Avlbty/Amt/Value`.
+        currency:
+          type: string
+          nullable: true
+          description: ISO `Bal/Avlbty/Amt/Ccy`.
+        date:
+          type: string
+          nullable: true
+          description: ISO `Bal/Avlbty/Dt` — `ActlDt` as `yyyy-MM-dd`, or synthetic `NBR_DAYS:{n}` from `NbOfDays`.
+    CamtCanonicalBalance:
+      type: object
+      description: |-
+        Reported balance (`CanonicalBalance`). Source: `Bal` under the account report or statement block (**052/053**;
+        not populated for **054** in the canonical mapper). ISO `CashBalance*` (`Tp`, `Amt`, `CdtDbtInd`, `Dt`, `Avlbty`).
+      properties:
+        type:
+          type: string
+          nullable: true
+          description: ISO `Bal/Tp/CdOrPrtry` (`Cd` or `Prtry`; v04 enum rendered as name when `Cd` used).
+        subType:
+          type: string
+          nullable: true
+          description: ISO `Bal/Tp/SubTp` (`Cd` or `Prtry`).
+        amount:
+          type: string
+          nullable: true
+          description: ISO `Bal/Amt/Value`.
+        currency:
+          type: string
+          nullable: true
+          description: ISO `Bal/Amt/Ccy`.
+        creditDebitIndicator:
+          type: string
+          nullable: true
+          description: ISO `Bal/CdtDbtInd`.
+        asOfDate:
+          type: string
+          nullable: true
+          description: ISO `Bal/Dt/Dt` (date-only branch of `DateAndDateTime*Choice`).
+        asOfDateTime:
+          type: string
+          nullable: true
+          description: ISO `Bal/Dt/DtTm` (date-time branch).
+        availability:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalBalanceAvailability'
+          nullable: true
+          description: ISO `Bal/Avlbty` (repeated).
+    CamtCanonicalEntry:
+      type: object
+      description: |-
+        One `Ntry` (report/statement/notification line) (`CanonicalEntry`). ISO tag `Ntry` (paths relative to the parent `Rpt` / `Stmt` / `Ntfctn` — see `CamtCanonicalDocument`).
+      properties:
+        entryReference:
+          type: string
+          nullable: true
+          description: ISO `Ntry/NtryRef`.
+        amount:
+          type: string
+          nullable: true
+          description: ISO `Ntry/Amt/Value`.
+        currency:
+          type: string
+          nullable: true
+          description: ISO `Ntry/Amt/Ccy`.
+        creditDebitIndicator:
+          type: string
+          nullable: true
+          description: ISO `Ntry/CdtDbtInd`.
+        entryStatus:
+          type: string
+          nullable: true
+          description: ISO `Ntry/Sts` (`Cd` or `Prtry`; v04 may use enum name when coded).
+        bookingStatus:
+          type: string
+          nullable: true
+          description: ISO `Ntry/AddtlInfInd` (`MsgNmId` or `MsgId`).
+        isReversal:
+          type: boolean
+          nullable: true
+          description: ISO `Ntry/RvslInd`.
+        numberOfTransactions:
+          type: integer
+          format: int32
+          nullable: true
+          description: Aggregated sum of `Ntry/NtryDtls/Btch/NbOfTxs` across all `NtryDtls` for the entry.
+        entryDetailsPresent:
+          type: boolean
+          nullable: true
+          description: Derived — `Ntry/NtryDtls` non-empty.
+        bookingDate:
+          type: string
+          nullable: true
+          description: ISO `Ntry/BookgDt/Dt`.
+        bookingDateTime:
+          type: string
+          nullable: true
+          description: ISO `Ntry/BookgDt/DtTm`.
+        valueDate:
+          type: string
+          nullable: true
+          description: ISO `Ntry/ValDt/Dt`.
+        valueDateTime:
+          type: string
+          nullable: true
+          description: ISO `Ntry/ValDt/DtTm`.
+        bankTransactionCode:
+          type: string
+          nullable: true
+          description: ISO shorthand from `Ntry/BkTxCd` (`Prtry/Cd` or `Domn/Cd`).
+        bankTransactionCodeStructured:
+          nullable: true
+          description: ISO full `Ntry/BkTxCd` breakdown.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalBankTransactionCode'
+        additionalEntryInformation:
+          type: string
+          nullable: true
+          description: ISO `Ntry/AddtlNtryInf`.
+        transactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalTransaction'
+          nullable: true
+          description: ISO flattened from `Ntry/NtryDtls/TxDtls` (all details for the entry).
+    CamtCanonicalAccount:
+      type: object
+      description: |-
+        Flattened account identification (`CanonicalAccount`). Source: `Acct/Id` (`IBAN`, `Othr/Id`); on **054** the same pattern applies to `RltdAcct` for `relatedAccount`.
+      properties:
+        iban:
+          type: string
+          nullable: true
+          description: ISO `Acct/Id/IBAN` (or `RltdAcct/Id/IBAN` for related account).
+        othrId:
+          type: string
+          nullable: true
+          description: ISO `Acct/Id/Othr/Id` (or `RltdAcct/Id/Othr/Id`).
+    CamtCanonicalPagination:
+      type: object
+      description: |-
+        Pagination (`CanonicalPagination`). ISO element name depends on message type: `RptPgntn`, `StmtPgntn`, or `NtfctnPgntn`; children `PgNb`, `LastPgInd`.
+      properties:
+        pageNumber:
+          type: string
+          nullable: true
+          description: ISO `PgNb`.
+        lastPage:
+          type: boolean
+          nullable: true
+          description: ISO `LastPgInd`.
+    CamtCanonicalPeriod:
+      type: object
+      description: |-
+        Reporting period (`CanonicalPeriod`). Source: `FrToDt` — v08 `DateTimePeriod1` (`FrDtTm`, `ToDtTm`); v04 `DateTimePeriodDetails` (same tags in XML).
+      properties:
+        from:
+          type: string
+          nullable: true
+          description: ISO `FrToDt/FrDtTm` (mapped to XML date-time string).
+        to:
+          type: string
+          nullable: true
+          description: ISO `FrToDt/ToDtTm`.
+    CamtCanonicalAccountOwner:
+      type: object
+      description: |-
+        Account owner (`CanonicalAccountOwner`). Source: `Acct/Ownr` (`PartyIdentification135` v08 or `PartyIdentification43` v04) — `Nm`, `Id` (flattened), `CtryOfRes`.
+      properties:
+        name:
+          type: string
+          nullable: true
+          description: ISO `Acct/Ownr/Nm`.
+        partyId:
+          type: string
+          nullable: true
+          description: ISO flattened from `Acct/Ownr/Id` (`OrgId/Othr/Id` or `PrvtId/Othr/Id`).
+        country:
+          type: string
+          nullable: true
+          description: ISO `Acct/Ownr/CtryOfRes`.
+    CamtCanonicalAccountServicer:
+      type: object
+      description: |-
+        Account servicer FI (`CanonicalAccountServicer`). Source: `Acct/Svcr/FinInstnId` — `BICFI`, `Nm`. `accountServicerBic` on the document duplicates `FinInstnId/BICFI` for convenience.
+      properties:
+        bic:
+          type: string
+          nullable: true
+          description: ISO `Acct/Svcr/FinInstnId/BICFI`.
+        name:
+          type: string
+          nullable: true
+          description: ISO `Acct/Svcr/FinInstnId/Nm`.
+    CamtCanonicalTransactionsSummary:
+      type: object
+      description: |-
+        **CAMT.054** notification totals (`CanonicalTransactionsSummary`). Source: `TxsSummry`
+        (v08 `TotalTransactions6`; v04 `TotalTransactions4`) — ISO `TtlNtries`, `TtlCdtNtries`, `TtlDbtNtries`.
+        Numeric fields serialize as JSON numbers from Java `BigDecimal`.
+      properties:
+        totalNumberOfEntries:
+          type: string
+          nullable: true
+          description: ISO `TxsSummry/TtlNtries/NbOfNtries`.
+        totalSum:
+          type: number
+          nullable: true
+          description: ISO `TxsSummry/TtlNtries/Sum`.
+        totalNetEntryAmount:
+          type: number
+          nullable: true
+          description: ISO `TxsSummry/TtlNtries/TtlNetNtry/Amt`.
+        totalNetCreditDebitIndicator:
+          type: string
+          nullable: true
+          description: ISO `TxsSummry/TtlNtries/TtlNetNtry/CdtDbtInd`.
+        creditEntriesNumber:
+          type: string
+          nullable: true
+          description: ISO `TxsSummry/TtlCdtNtries/NbOfNtries`.
+        creditSum:
+          type: number
+          nullable: true
+          description: ISO `TxsSummry/TtlCdtNtries/Sum`.
+        debitEntriesNumber:
+          type: string
+          nullable: true
+          description: ISO `TxsSummry/TtlDbtNtries/NbOfNtries`.
+        debitSum:
+          type: number
+          nullable: true
+          description: ISO `TxsSummry/TtlDbtNtries/Sum`.
+    CamtCanonicalDocument:
+      type: object
+      description: |-
+        One logical CAMT payload (`CanonicalCamtDocument`). ISO message roots: **052** `BkToCstmrAcctRpt` → `Rpt`;
+        **053** `BkToCstmrStmt` → `Stmt`; **054** `BkToCstmrDbtCdtNtfctn` → `Ntfctn`. `originalMessageId` is `GrpHdr/MsgId`
+        on that root. Other property paths are relative to `Rpt` / `Stmt` / `Ntfctn` unless noted (e.g. 054-only fields).
+      properties:
+        sourceZipEntry:
+          type: string
+          nullable: true
+          description: Application — name of the XML file inside the BTD ZIP (not an ISO 20022 element).
+        originalMessageId:
+          type: string
+          nullable: true
+          description: ISO `GrpHdr/MsgId` on `BkToCstmrAcctRpt`, `BkToCstmrStmt`, or `BkToCstmrDbtCdtNtfctn`.
+        documentType:
+          type: string
+          nullable: true
+          description: |-
+            Derived CAMT family for JSON (`camt.052` / `camt.053` / `camt.054` via Java `@JsonValue`; examples may show `CAMT052` style).
+            ISO side is the message root (`BkToCstmrAcctRpt`, `BkToCstmrStmt`, `BkToCstmrDbtCdtNtfctn`).
+          example: CAMT052
+        documentId:
+          type: string
+          nullable: true
+          description: ISO `Id`.
+        electronicSequenceNumber:
+          type: string
+          nullable: true
+          description: ISO `ElctrncSeqNb`.
+        legalSequenceNumber:
+          type: string
+          nullable: true
+          description: ISO `LglSeqNb`.
+        pagination:
+          nullable: true
+          description: ISO `RptPgntn`, `StmtPgntn`, or `NtfctnPgntn` (name depends on CAMT type).
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalPagination'
+        creationDateTime:
+          type: string
+          nullable: true
+          description: ISO `CreDtTm`.
+        period:
+          nullable: true
+          description: ISO `FrToDt`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalPeriod'
+        additionalInfo:
+          type: string
+          nullable: true
+          description: ISO `AddtlRptInf` (052), `AddtlStmtInf` (053), or `AddtlNtfctnInf` (054).
+        account:
+          nullable: true
+          description: ISO `Acct` (`Id/IBAN`, `Id/Othr/Id`).
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalAccount'
+        accountName:
+          type: string
+          nullable: true
+          description: ISO `Acct/Nm`.
+        accountOwner:
+          nullable: true
+          description: ISO `Acct/Ownr`.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalAccountOwner'
+        accountCurrency:
+          type: string
+          nullable: true
+          description: ISO `Acct/Ccy`.
+        accountServicerBic:
+          type: string
+          nullable: true
+          description: ISO `Acct/Svcr/FinInstnId/BICFI` (duplicate for convenience).
+        accountServicer:
+          nullable: true
+          description: ISO `Acct/Svcr` (`FinInstnId/BICFI`, `FinInstnId/Nm`).
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalAccountServicer'
+        balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalBalance'
+          nullable: true
+          description: ISO `Bal` (052/053 only; omitted for 054 in the mapper).
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalEntry'
+          nullable: true
+          description: ISO repeated `Ntry`.
+        relatedAccount:
+          nullable: true
+          description: |-
+            **CAMT.054** only — ISO `RltdAcct` (`Id/IBAN`, `Id/Othr/Id` flattened like main `Acct`).
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalAccount'
+        copyDuplicateIndicator:
+          type: string
+          nullable: true
+          description: "**CAMT.054** only — ISO `CpyDplctInd`."
+        reportingSource:
+          type: string
+          nullable: true
+          description: "**CAMT.054** only — ISO `RptgSrc` (`Cd` or `Prtry` flattened to one string)."
+        transactionsSummary:
+          nullable: true
+          description: "**CAMT.054** only — ISO `TxsSummry`."
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalTransactionsSummary'
+    CamtCanonicalParseResult:
+      type: object
+      description: |-
+        Wrapper for all parsed logical documents (`CanonicalCamtParseResult`). One `documents[]` item per `Rpt` (052),
+        `Stmt` (053), or `Ntfctn` (054) inside each XML from the BTD ZIP (see `CamtCanonicalDocument`).
+      properties:
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/CamtCanonicalDocument'
+          nullable: true
+          description: One element per logical report, statement, or notification block after mapping.
+    CamtCanonicalParseResponse:
+      type: object
+      description: |-
+        Parsed CAMT response in **compact canonical** JSON: BTD-style metadata (`status`, `message`, EBICS return codes when present) plus `parseResult` with `documents` (balances, entries, transactions — field set varies slightly by CAMT flavour).
+
+        On failure the service may return HTTP **500** with `status` = `ERROR` and `message` populated.
+      additionalProperties: true
+      properties:
+        ebicsUserId:
+          type: string
+          nullable: true
+        orderType:
+          type: string
+          example: C52
+        status:
+          type: string
+        message:
+          type: string
+          nullable: true
+        dataAvailabilityStatus:
+          type: string
+          nullable: true
+        headerReturnCode:
+          type: string
+          nullable: true
+        headerReturnText:
+          type: string
+          nullable: true
+        bodyReturnCode:
+          type: string
+          nullable: true
+        bodyReturnText:
+          type: string
+          nullable: true
+        bodyReturnSymbolicName:
+          type: string
+          nullable: true
+        parseResult:
+          description: |-
+            Parsed CAMT payload (`CanonicalCamtParseResult`): `documents[]` mirrors one `Rpt` / `Stmt` / `Ntfctn` per item.
+          allOf:
+            - $ref: '#/components/schemas/CamtCanonicalParseResult'
+    CamtIsoParseResponse:
+      type: object
+      description: |-
+        Parsed CAMT response in **ISO element–aligned** JSON: metadata as for canonical responses, plus a `files` array mirroring ZIP entries. Each file has `zipEntryName`, `schemaNamespace`, and a `Document` object whose root follows the XSD (`BkToCstmrAcctRpt` for CAMT.052, `BkToCstmrStmt` for .053, `BkToCstmrDbtCdtNtfctn` for .054).
+
+        **CAMT.054** adds notification-specific structures (`Ntfctn`, `NtfctnPgntn`, etc.).
+      additionalProperties: true
+      properties:
+        ebicsUserId:
+          type: string
+          nullable: true
+        orderType:
+          type: string
+          example: C52
+        status:
+          type: string
+        message:
+          type: string
+          nullable: true
+        dataAvailabilityStatus:
+          type: string
+          nullable: true
+        headerReturnCode:
+          type: string
+          nullable: true
+        headerReturnText:
+          type: string
+          nullable: true
+        bodyReturnCode:
+          type: string
+          nullable: true
+        bodyReturnText:
+          type: string
+          nullable: true
+        bodyReturnSymbolicName:
+          type: string
+          nullable: true
+        files:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: One element per parsed XML inside the BTD ZIP.

--- a/scripts/gen_camt_parse_openapi.rb
+++ b/scripts/gen_camt_parse_openapi.rb
@@ -1,0 +1,459 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+# frozen_string_literal: true
+
+require "json"
+require "yaml"
+
+CLIENT_ROOT = File.expand_path("../../billte-ebics-client", __dir__)
+JAVA = File.read(
+  File.join(CLIENT_ROOT, "src/main/java/ch/billte/ebics/api/EbicsV3CamtOpenApiExamples.java"),
+  encoding: "UTF-8"
+)
+
+def extract_java_string_literal(const_name)
+  re = /public static final String #{Regexp.escape(const_name)} = "/m
+  m = JAVA.match(re)
+  raise "missing #{const_name}" unless m
+
+  i = m.end(0)
+  buf = +""
+  while i < JAVA.length
+    c = JAVA[i]
+    if c == "\\" && i + 1 < JAVA.length
+      buf << c << JAVA[i + 1]
+      i += 2
+      next
+    end
+    break if c == '"'
+
+    buf << c
+    i += 1
+  end
+  buf.gsub(/\\u([0-9a-fA-F]{4})/i) { [::Regexp.last_match(1).to_i(16)].pack("U*") }
+     .gsub("\\\\", "\u0000ESC\u0000")
+     .gsub('\\"', '"')
+     .gsub("\\n", "\n")
+     .gsub("\\r", "\r")
+     .gsub("\\t", "\t")
+     .gsub("\u0000ESC\u0000", "\\")
+end
+
+def example_json(const_name)
+  JSON.parse(extract_java_string_literal(const_name))
+end
+
+EX = {
+  "c52_canonical_04" => example_json("C52_CANONICAL_RICH_052_001_04_EXAMPLE"),
+  "c52_canonical_08" => example_json("C52_CANONICAL_RICH_052_001_08_EXAMPLE"),
+  "c52_iso_04" => example_json("C52_ISO_RICH_052_001_04_EXAMPLE"),
+  "c52_iso_08" => example_json("C52_ISO_RICH_052_001_08_EXAMPLE"),
+  "c53_canonical_04" => example_json("C53_CANONICAL_RICH_053_001_04_EXAMPLE"),
+  "c53_canonical_08" => example_json("C53_CANONICAL_RICH_053_001_08_EXAMPLE"),
+  "c53_iso_04" => example_json("C53_ISO_RICH_053_001_04_EXAMPLE"),
+  "c53_iso_08" => example_json("C53_ISO_RICH_053_001_08_EXAMPLE"),
+  "c54_canonical_04" => example_json("C54_CANONICAL_RICH_054_001_04_EXAMPLE"),
+  "c54_canonical_08" => example_json("C54_CANONICAL_RICH_054_001_08_EXAMPLE"),
+  "c54_iso_04" => example_json("C54_ISO_RICH_054_001_04_EXAMPLE"),
+  "c54_iso_08" => example_json("C54_ISO_RICH_054_001_08_EXAMPLE")
+}.freeze
+
+REQ_ACTUAL = {
+  "ebicsUserId" => "ZKB03305",
+  "billerId" => "billte-ch"
+}.freeze
+
+def clone_json(obj)
+  JSON.parse(JSON.generate(obj))
+end
+
+REQ_HIST_C52 = {
+  "ebicsUserId" => "ZKB03305",
+  "billerId" => "billte-ch",
+  "startDate" => "2026-04-20",
+  "endDate" => "2026-04-20"
+}.freeze
+
+REQ_HIST_C53_C54 = {
+  "ebicsUserId" => "ZKB03305",
+  "billerId" => "billte-ch",
+  "startDate" => "2026-04-01",
+  "endDate" => "2026-04-20"
+}.freeze
+
+MAIN_OPENAPI = "ebics-biller-api.yml"
+
+def standard_errors(canonical:)
+  schema_ref = canonical ? "#/components/schemas/CamtCanonicalParseResponse" : "#/components/schemas/CamtIsoParseResponse"
+  err_ref = "#{MAIN_OPENAPI}#/components/schemas/ErrorResponse"
+  {
+    "401" => {
+      "description" => <<~TXT.strip,
+        Unauthorized. Returned when:
+        - the JWT is missing, invalid, or lacks the `EBICS` scope, or
+        - the biller's `ebicsStatus` is no longer `ACTIVE` after the token was issued.
+      TXT
+      "content" => {
+        "application/json" => {
+          "schema" => { "$ref" => err_ref },
+          "examples" => {
+            "missingEbicsScope" => {
+              "summary" => "JWT is missing the EBICS scope",
+              "value" => { "error" => "Unauthorized: missing EBICS scope" }
+            },
+            "ebicsStatusInactive" => {
+              "summary" => "Biller is no longer EBICS-active",
+              "description" => "Returned when `ebicsStatus` flips off after the JWT was issued.",
+              "value" => { "error" => "Unauthorized: billerPid is not valid or biller is not active" }
+            }
+          }
+        }
+      }
+    },
+    "500" => {
+      "description" => "Unexpected server error or BTD error payload (`status` = `ERROR`).",
+      "content" => {
+        "application/json" => {
+          "schema" => { "$ref" => schema_ref }
+        }
+      }
+    }
+  }
+end
+
+def camt_post(path, operation_id, summary, description, iso, examples_200)
+  schema_ref = iso ? "#/components/schemas/CamtIsoParseResponse" : "#/components/schemas/CamtCanonicalParseResponse"
+  hist = path.include?("C52") ? REQ_HIST_C52 : REQ_HIST_C53_C54
+
+  body_desc =
+    if path.include?("C52")
+      "Minimal payloads omit serviceName, scope, msgName, msgNameVersion, containerType — defaults apply (STM, CH, camt.052, 08, ZIP). " \
+        "Actual vs historical download follows the same rule as BTD: without dates = actual; with startDate/endDate = historical."
+    elsif path.include?("C53")
+      "Minimal payloads omit serviceName, scope, msgName, msgNameVersion, containerType — defaults apply (EOP, CH, camt.053, 08, ZIP). " \
+        "Actual vs historical download follows the same rule as BTD: without dates = actual; with startDate/endDate = historical."
+    else
+      "Minimal payloads omit serviceName, scope, msgName, msgNameVersion, containerType — defaults apply (REP, CH, camt.054, 08, ZIP). " \
+        "Actual vs historical download follows the same rule as BTD: without dates = actual; with startDate/endDate = historical."
+    end
+
+  ex_hist =
+    if path.include?("C52")
+      { summary: "Intraday account report request (Historical)", desc: "Camt052 v08 Statement (Historical Download for given date range)" }
+    elsif path.include?("C53")
+      { summary: "Daily account statement request (Historical)", desc: "Camt053 v08 Statement (Historical Download for given date range)" }
+    else
+      { summary: "Credit/Debit Notifications request (Historical)", desc: "Camt054 v08 Credit/Debit Notifications (Historical Download for given date range)" }
+    end
+
+  ex_act =
+    if path.include?("C52")
+      { summary: "Intraday account report request (Actual)", desc: "Camt052 v08 Statement (Actual download of not-yet downloaded files from bank.)" }
+    elsif path.include?("C53")
+      { summary: "Daily account statement request (Actual)", desc: "Camt053 v08 Statement (Actual download of not-yet downloaded files from bank.)" }
+    else
+      { summary: "Credit/Debit Notifications request (Actual)", desc: "Camt054 v08 Credit/Debit Notifications (Actual download of not-yet downloaded files from bank.)" }
+    end
+
+  {
+    "post" => {
+      "summary" => summary,
+      "description" => description,
+      "operationId" => operation_id,
+      "tags" => ["EBICS v3"],
+      "requestBody" => {
+        "required" => true,
+        "description" => body_desc,
+        "content" => {
+          "application/json" => {
+            "schema" => { "$ref" => "#/components/schemas/CamtBtdDerivedParseRequest" },
+            "examples" => {
+              "actualMinimal" => {
+                "summary" => ex_act[:summary],
+                "description" => ex_act[:desc],
+                "value" => clone_json(REQ_ACTUAL)
+              },
+              "historicalMinimal" => {
+                "summary" => ex_hist[:summary],
+                "description" => ex_hist[:desc],
+                "value" => clone_json(hist)
+              }
+            }
+          }
+        }
+      },
+      "responses" => {
+        "200" => {
+          "description" => "Parsed successfully or BTD returned with error payload",
+          "content" => {
+            "application/json" => {
+              "schema" => { "$ref" => schema_ref },
+              "examples" => examples_200
+            }
+          }
+        }
+      }.merge(standard_errors(canonical: !iso))
+    }
+  }
+end
+
+schemas = {
+  "CamtBtdDerivedParseRequest" => {
+    "type" => "object",
+    "description" => <<~MD.strip,
+      Request body for CAMT C52/C53/C54 **ISO** or **canonical** parse operations (mirrors EBICS client `BaseBTDRequest` / `C52Request` / `C53Request` / `C54Request`).
+
+      **Defaults when omitted** depend on the order type (see each path):
+      - **C52**: `serviceName` STM, `scope` CH, `msgName` camt.052, `msgNameVersion` 08, `containerType` ZIP
+      - **C53**: `serviceName` EOP, `scope` CH, `msgName` camt.053, `msgNameVersion` 08, `containerType` ZIP
+      - **C54**: `serviceName` REP, `scope` CH, `msgName` camt.054, `msgNameVersion` 08, `containerType` ZIP
+
+      **Actual vs historical**: same rule as BTD — omit both dates for *actual* (not-yet-downloaded) data; send `startDate` and `endDate` together for a historical window (`yyyy-MM-dd`).
+    MD
+    "properties" => {
+      "requestId" => { "type" => "string", "nullable" => true, "description" => "Optional correlation id; often set server-side." },
+      "ebicsUserId" => { "type" => "string", "description" => "EBICS user id (direct EBICS client). When proxied through eBillGuardian, this may be resolved from the JWT.", "example" => "ZKB03305" },
+      "billerId" => { "type" => "string", "description" => "Biller tenant id (direct client). May be resolved from JWT when proxied.", "example" => "billte-ch" },
+      "startDate" => { "type" => "string", "format" => "date", "nullable" => true, "description" => "Historical range start (inclusive)." },
+      "endDate" => { "type" => "string", "format" => "date", "nullable" => true, "description" => "Historical range end (inclusive)." },
+      "serviceName" => { "type" => "string", "nullable" => true, "description" => "BTF service name (defaults per order type if omitted)." },
+      "scope" => { "type" => "string", "nullable" => true, "description" => "BTF scope (default CH)." },
+      "msgName" => { "type" => "string", "nullable" => true, "description" => "ISO message name (default camt.052 / .053 / .054 per path)." },
+      "msgNameVersion" => { "type" => "string", "nullable" => true, "description" => "Message version (default 08)." },
+      "msgNameFormat" => { "type" => "string", "nullable" => true, "description" => "Message format (default XML in client)." },
+      "containerType" => { "type" => "string", "nullable" => true, "description" => "Container type (default ZIP)." }
+    }
+  },
+  "CamtCanonicalParseResponse" => {
+    "type" => "object",
+    "description" => <<~MD.strip,
+      Parsed CAMT response in **compact canonical** JSON: BTD-style metadata (`status`, `message`, EBICS return codes when present) plus `parseResult` with `documents` (balances, entries, transactions — field set varies slightly by CAMT flavour).
+
+      On failure the service may return HTTP **500** with `status` = `ERROR` and `message` populated.
+    MD
+    "additionalProperties" => true,
+    "properties" => {
+      "ebicsUserId" => { "type" => "string", "nullable" => true },
+      "orderType" => { "type" => "string", "example" => "C52" },
+      "status" => { "type" => "string" },
+      "message" => { "type" => "string", "nullable" => true },
+      "dataAvailabilityStatus" => { "type" => "string", "nullable" => true },
+      "headerReturnCode" => { "type" => "string", "nullable" => true },
+      "headerReturnText" => { "type" => "string", "nullable" => true },
+      "bodyReturnCode" => { "type" => "string", "nullable" => true },
+      "bodyReturnText" => { "type" => "string", "nullable" => true },
+      "bodyReturnSymbolicName" => { "type" => "string", "nullable" => true },
+      "parseResult" => { "type" => "object", "additionalProperties" => true, "description" => "Canonical documents and nested entries." }
+    }
+  },
+  "CamtIsoParseResponse" => {
+    "type" => "object",
+    "description" => <<~MD.strip,
+      Parsed CAMT response in **ISO element–aligned** JSON: metadata as for canonical responses, plus a `files` array mirroring ZIP entries. Each file has `zipEntryName`, `schemaNamespace`, and a `Document` object whose root follows the XSD (`BkToCstmrAcctRpt` for CAMT.052, `BkToCstmrStmt` for .053, `BkToCstmrDbtCdtNtfctn` for .054).
+
+      **CAMT.054** adds notification-specific structures (`Ntfctn`, `NtfctnPgntn`, etc.).
+    MD
+    "additionalProperties" => true,
+    "properties" => {
+      "ebicsUserId" => { "type" => "string", "nullable" => true },
+      "orderType" => { "type" => "string", "example" => "C52" },
+      "status" => { "type" => "string" },
+      "message" => { "type" => "string", "nullable" => true },
+      "dataAvailabilityStatus" => { "type" => "string", "nullable" => true },
+      "headerReturnCode" => { "type" => "string", "nullable" => true },
+      "headerReturnText" => { "type" => "string", "nullable" => true },
+      "bodyReturnCode" => { "type" => "string", "nullable" => true },
+      "bodyReturnText" => { "type" => "string", "nullable" => true },
+      "bodyReturnSymbolicName" => { "type" => "string", "nullable" => true },
+      "files" => { "type" => "array", "items" => { "type" => "object", "additionalProperties" => true }, "description" => "One element per parsed XML inside the BTD ZIP." }
+    }
+  }
+}
+
+# Path order matches `ebics-biller-api.yml` $refs (canonical C52/C53/C54, then ISO).
+paths = {
+  "/client/ebics/v3/C52-canonical" => camt_post(
+    "/client/ebics/v3/C52-canonical",
+    "v3C52Canonical",
+    "C52 canonical parse (CAMT.052)",
+    <<~MD.strip,
+      Downloads CAMT.052 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns compact canonical documents, balances, entries, and transactions.
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C52-canonical`.
+    MD
+    false,
+    {
+      "camt052Canonical00104" => {
+        "summary" => "CAMT.052.001.04 — canonical JSON",
+        "description" => "This is example of mapping a camt.052.001.04 to canonical JSON",
+        "value" => EX["c52_canonical_04"]
+      },
+      "camt052Canonical00108" => {
+        "summary" => "CAMT.052.001.08 — canonical JSON",
+        "description" => "This is example of mapping a camt.052.001.08 to canonical JSON",
+        "value" => EX["c52_canonical_08"]
+      }
+    }
+  ),
+  "/client/ebics/v3/C53-canonical" => camt_post(
+    "/client/ebics/v3/C53-canonical",
+    "v3C53Canonical",
+    "C53 canonical parse (CAMT.053)",
+    <<~MD.strip,
+      Downloads CAMT.053 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns compact canonical documents, balances, entries, and transactions.
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C53-canonical`.
+    MD
+    false,
+    {
+      "camt053Canonical00104" => {
+        "summary" => "CAMT.053.001.04 — canonical JSON",
+        "description" => "This is example of mapping a camt.053.001.04 to canonical JSON",
+        "value" => EX["c53_canonical_04"]
+      },
+      "camt053Canonical00108" => {
+        "summary" => "CAMT.053.001.08 — canonical JSON",
+        "description" => "This is example of mapping a camt.053.001.08 to canonical JSON",
+        "value" => EX["c53_canonical_08"]
+      }
+    }
+  ),
+  "/client/ebics/v3/C54-canonical" => camt_post(
+    "/client/ebics/v3/C54-canonical",
+    "v3C54Canonical",
+    "C54 canonical parse (CAMT.054)",
+    <<~MD.strip,
+      Downloads CAMT.054 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns compact canonical documents and entries.
+      Compared to C52/C53, CAMT.054 adds notification-specific fields: `relatedAccount` (`RltdAcct`),
+      `copyDuplicateIndicator`, `reportingSource`, `transactionsSummary` (`TxsSummry`), and omits statement-style `balances`
+      when not present in the message. Each BTD XML notification maps to one element in `parseResult.documents`.
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C54-canonical`.
+    MD
+    false,
+    {
+      "camt054Canonical00104" => {
+        "summary" => "CAMT.054.001.04 — canonical JSON",
+        "description" => "This is example of mapping a camt.054.001.04 to canonical JSON",
+        "value" => EX["c54_canonical_04"]
+      },
+      "camt054Canonical00108" => {
+        "summary" => "CAMT.054.001.08 — canonical JSON",
+        "description" => "This is example of mapping a camt.054.001.08 to canonical JSON",
+        "value" => EX["c54_canonical_08"]
+      }
+    }
+  ),
+  "/client/ebics/v3/C52-iso" => camt_post(
+    "/client/ebics/v3/C52-iso",
+    "v3C52Iso",
+    "C52 ISO-structured parse (CAMT.052)",
+    <<~MD.strip,
+      Downloads CAMT.052 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns ISO element–aligned JSON (camt.052.001.04 / .08).
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C52-iso`.
+    MD
+    true,
+    {
+      "camt052Iso00104" => {
+        "summary" => "CAMT.052.001.04 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.052.001.04 to ISO-shaped JSON",
+        "value" => EX["c52_iso_04"]
+      },
+      "camt052Iso00108" => {
+        "summary" => "CAMT.052.001.08 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.052.001.08 to ISO-shaped JSON",
+        "value" => EX["c52_iso_08"]
+      }
+    }
+  ),
+  "/client/ebics/v3/C53-iso" => camt_post(
+    "/client/ebics/v3/C53-iso",
+    "v3C53Iso",
+    "C53 ISO-structured parse (CAMT.053)",
+    <<~MD.strip,
+      Downloads CAMT.053 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns ISO element–aligned JSON (camt.053.001.04 / .08).
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C53-iso`.
+    MD
+    true,
+    {
+      "camt053Iso00104" => {
+        "summary" => "CAMT.053.001.04 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.053.001.04 to ISO-shaped JSON",
+        "value" => EX["c53_iso_04"]
+      },
+      "camt053Iso00108" => {
+        "summary" => "CAMT.053.001.08 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.053.001.08 to ISO-shaped JSON",
+        "value" => EX["c53_iso_08"]
+      }
+    }
+  ),
+  "/client/ebics/v3/C54-iso" => camt_post(
+    "/client/ebics/v3/C54-iso",
+    "v3C54Iso",
+    "C54 ISO-structured parse (CAMT.054)",
+    <<~MD.strip,
+      Downloads CAMT.054 via BTD keeping the file local (no cloud upload), parses ZIP/XML with JAXB,
+      and returns ISO element–aligned JSON (camt.054.001.04 / .08).
+      The `files` array mirrors ZIP entries: each item has `zipEntryName`, `schemaNamespace`, and a `Document` object
+      with `BkToCstmrDbtCdtNtfctn` (group header, `Ntfctn` notifications, entries `Ntry`, related account `RltdAcct`,
+      `TxsSummry`, etc.). CAMT.054 is a debit/credit notification; pagination uses `NtfctnPgntn`.
+
+      Source: Billte EBICS client `EbicsV3Controller` — `POST /api/ebics/v3/C54-iso`.
+    MD
+    true,
+    {
+      "camt054Iso00104" => {
+        "summary" => "CAMT.054.001.04 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.054.001.04 to ISO-shaped JSON",
+        "value" => EX["c54_iso_04"]
+      },
+      "camt054Iso00108" => {
+        "summary" => "CAMT.054.001.08 — ISO-shaped JSON",
+        "description" => "This is example of mapping a camt.054.001.08 to ISO-shaped JSON",
+        "value" => EX["c54_iso_08"]
+      }
+    }
+  )
+}
+
+def path_item_json_pointer(path)
+  "#/paths/" + path.gsub("~", "~0").gsub("/", "~1")
+end
+
+out = File.expand_path("../ebics-biller-camt-api.yaml", __dir__)
+doc = {
+  "openapi" => "3.0.3",
+  "info" => {
+    "title" => "EBICS Biller API — CAMT parse (fragment)",
+    "version" => "1.0.0",
+    "description" => <<~MD.strip
+      **Fragment** merged into the main EBICS Biller OpenAPI via `$ref` from `#{MAIN_OPENAPI}`.
+
+      Contains CAMT **C52 / C53 / C54** `*-iso` and `*-canonical` path definitions and their schemas (`CamtBtdDerivedParseRequest`, `CamtCanonicalParseResponse`, `CamtIsoParseResponse`).
+
+      `ErrorResponse` for HTTP 401 is referenced from `#{MAIN_OPENAPI}`.
+
+      Regenerate from Java examples: `RUBYOPT='-EUTF-8:UTF-8' ruby scripts/gen_camt_parse_openapi.rb` (run from repo root `ebill-swp-redoc/`).
+    MD
+  },
+  "paths" => paths,
+  "components" => {
+    "schemas" => schemas
+  }
+}
+yaml = YAML.dump(doc)
+yaml.gsub!(/("\$ref"): (ebics-biller-api\.yml#\S+)/, '\1: "\2"')
+File.write(out, yaml)
+puts "OK #{out}"
+puts "Path item pointers (for main spec $ref):"
+paths.each_key do |p|
+  puts "  #{p} -> ./#{File.basename(out)}#{path_item_json_pointer(p)}"
+end


### PR DESCRIPTION
- Introduced new `ebics-biller-camt-api.yaml` file for CAMT C52/C53/C54 parsing, including ISO and canonical formats.
- Added detailed path definitions for downloading CAMT statements and their corresponding schemas.
- Updated `ebics-biller-api.yml` to include new BTF descriptors and refined existing endpoint descriptions.
- Implemented a Ruby script to generate example JSON payloads for CAMT requests based on Java examples.